### PR TITLE
Added django permission support for table access restriction

### DIFF
--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -27,3 +27,6 @@ S3_ACCESS_KEY = getattr(settings, "EXPLORER_S3_ACCESS_KEY", None)
 S3_SECRET_KEY = getattr(settings, "EXPLORER_S3_SECRET_KEY", None)
 S3_BUCKET = getattr(settings, "EXPLORER_S3_BUCKET", None)
 FROM_EMAIL = getattr(settings, 'EXPLORER_FROM_EMAIL', 'django-sql-explorer@example.com')
+
+# Table level permissions
+EXPLORER_TABLE_LEVEL_PERMISSION = getattr(settings, "EXPLORER_TABLE_LEVEL_PERMISSION", False)

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -29,4 +29,4 @@ S3_BUCKET = getattr(settings, "EXPLORER_S3_BUCKET", None)
 FROM_EMAIL = getattr(settings, 'EXPLORER_FROM_EMAIL', 'django-sql-explorer@example.com')
 
 # Table level permissions
-EXPLORER_TABLE_LEVEL_PERMISSION = getattr(settings, "EXPLORER_TABLE_LEVEL_PERMISSION", False)
+EXPLORER_TABLE_LEVEL_PERMISSION = lambda: getattr(settings, "EXPLORER_TABLE_LEVEL_PERMISSION", False)

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -1,4 +1,4 @@
-from explorer.utils import passes_blacklist, swap_params, extract_params, shared_dict_update, get_connection, get_s3_connection
+from explorer.utils import passes_blacklist, swap_params, extract_params, shared_dict_update, get_connection, get_s3_connection, is_table_restricted
 from django.db import models, DatabaseError
 from time import time
 from django.core.urlresolvers import reverse
@@ -51,6 +51,8 @@ class Query(models.Model):
 
     def execute_with_logging(self, executing_user):
         ql = self.log(executing_user)
+        if app_settings.EXPLORER_TABLE_LEVEL_PERMISSION and is_table_restricted(self.final_sql(), executing_user):
+            raise DatabaseError("Table access restricted")
         ret = self.execute()
         ql.duration = ret.duration
         ql.save()

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -51,7 +51,7 @@ class Query(models.Model):
 
     def execute_with_logging(self, executing_user):
         ql = self.log(executing_user)
-        if (executing_user is not None) and app_settings.EXPLORER_TABLE_LEVEL_PERMISSION and is_table_restricted(self.final_sql(), executing_user):
+        if (executing_user is not None) and app_settings.EXPLORER_TABLE_LEVEL_PERMISSION() and is_table_restricted(self.final_sql(), executing_user):
             raise DatabaseError("Table access restricted")
         ret = self.execute()
         ql.duration = ret.duration

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -51,7 +51,7 @@ class Query(models.Model):
 
     def execute_with_logging(self, executing_user):
         ql = self.log(executing_user)
-        if app_settings.EXPLORER_TABLE_LEVEL_PERMISSION and is_table_restricted(self.final_sql(), executing_user) and executing_user is not None:
+        if (executing_user is not None) and app_settings.EXPLORER_TABLE_LEVEL_PERMISSION and is_table_restricted(self.final_sql(), executing_user):
             raise DatabaseError("Table access restricted")
         ret = self.execute()
         ql.duration = ret.duration

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -51,7 +51,7 @@ class Query(models.Model):
 
     def execute_with_logging(self, executing_user):
         ql = self.log(executing_user)
-        if app_settings.EXPLORER_TABLE_LEVEL_PERMISSION and is_table_restricted(self.final_sql(), executing_user):
+        if app_settings.EXPLORER_TABLE_LEVEL_PERMISSION and is_table_restricted(self.final_sql(), executing_user) and executing_user is not None:
             raise DatabaseError("Table access restricted")
         ret = self.execute()
         ql.duration = ret.duration

--- a/explorer/tests/settings.py
+++ b/explorer/tests/settings.py
@@ -58,3 +58,4 @@ EXPLORER_TASKS_ENABLED = True
 CELERY_ALWAYS_EAGER = True
 BROKER_BACKEND = 'memory'
 EXPLORER_S3_BUCKET = 'thisismybucket.therearemanylikeit.butthisoneismine'
+EXPLORER_TABLE_LEVEL_PERMISSION = False

--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -420,11 +420,19 @@ class TestPermissionBasedExecutionView(TestCase):
         self.assertTemplateUsed(resp, 'explorer/play.html')
 
     def test_playground_renders_with_restricted_table_sql(self):
-        resp = self.client.post(reverse("explorer_playground"), {'sql': 'select * from auth_user;'})
+        with self.settings(EXPLORER_TABLE_LEVEL_PERMISSION=True):
+            resp = self.client.post(reverse("explorer_playground"), {'sql': 'select * from auth_user;'})
         self.assertTemplateUsed(resp, 'explorer/play.html')
         self.assertContains(resp, 'Table access restricted')
 
     def test_playground_renders_with_allowed_table_sql(self):
-        resp = self.client.post(reverse("explorer_playground"), {'sql': 'select * from django_session;'})
+        with self.settings(EXPLORER_TABLE_LEVEL_PERMISSION=True):
+            resp = self.client.post(reverse("explorer_playground"), {'sql': 'select * from django_session;'})
+        self.assertTemplateUsed(resp, 'explorer/play.html')
+        self.assertNotContains(resp, 'Table access restricted')
+
+    def test_playground_renders_with_allowed_table_sql(self):
+        with self.settings(EXPLORER_TABLE_LEVEL_PERMISSION=True):
+            resp = self.client.post(reverse("explorer_playground"), {'sql': ''})
         self.assertTemplateUsed(resp, 'explorer/play.html')
         self.assertNotContains(resp, 'Table access restricted')

--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -431,7 +431,7 @@ class TestPermissionBasedExecutionView(TestCase):
         self.assertTemplateUsed(resp, 'explorer/play.html')
         self.assertNotContains(resp, 'Table access restricted')
 
-    def test_playground_renders_with_allowed_table_sql(self):
+    def test_playground_renders_with_empty_sql(self):
         with self.settings(EXPLORER_TABLE_LEVEL_PERMISSION=True):
             resp = self.client.post(reverse("explorer_playground"), {'sql': ''})
         self.assertTemplateUsed(resp, 'explorer/play.html')

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -141,6 +141,8 @@ def csv_report(query, delim=None):
 
 
 def is_table_restricted(query, user):
+    if user is None:
+        return True
     apps = [a for a in models.get_apps()]
     all_models = []
     model_to_app = {}

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -157,7 +157,10 @@ def is_table_restricted(query, user):
         from_found = False
         while is_true:
             try:
-                temp = parsed_generator.next()
+                if PY3:
+                    temp = parsed_generator.__next__()
+                else:
+                    temp = parsed_generator.next()
                 if temp.ttype == Name and from_found:
                     stream_new.append(temp.value)
                 elif temp.value.upper() == 'FROM' and temp.ttype == Keyword:

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -15,6 +15,7 @@ from django.db import connections, connection, models, DatabaseError
 from django.http import HttpResponse
 from six.moves import cStringIO
 import sqlparse
+from sqlparse.tokens import Name, Keyword
 
 EXPLORER_PARAM_TOKEN = "$$"
 
@@ -137,6 +138,38 @@ def csv_report(query, delim=None):
         return write_csv(res.headers, res.data, delim)
     except DatabaseError as e:
         return str(e)
+
+
+def is_table_restricted(query, user):
+    if user.is_anonymous():
+        return True
+    apps = [a for a in models.get_apps()]
+    all_models = []
+    model_to_app = {}
+    for app in apps:
+        for model in models.get_models(app):
+            all_models.append("%s" % (model._meta.db_table.lower()))
+            model_to_app[model._meta.db_table.lower()] = [app.__package__.split('.')[-1], model._meta.model_name.lower()]
+    x = sqlparse.parse(query)[0]
+    b = x.flatten()
+    stream_new = []
+    is_true = True
+    from_found = False
+    while is_true:
+        try:
+            c = b.next()
+            if c.ttype == Name and from_found:
+                stream_new.append(c.value)
+            elif c.value.upper() == 'FROM' and c.ttype == Keyword:
+                from_found = True
+            elif c.ttype == Keyword:
+                from_found = False
+            else:
+                pass
+        except:
+            is_true = False
+    tables_accessed = set(all_models).intersection(set(stream_new))
+    return not user.has_perms(['{0}.change_{1}'.format(model_to_app[table][0], model_to_app[table][1]) for table in tables_accessed])
 
 
 # Helpers

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -141,8 +141,6 @@ def csv_report(query, delim=None):
 
 
 def is_table_restricted(query, user):
-    if user is None:
-        return True
     apps = [a for a in models.get_apps()]
     all_models = []
     model_to_app = {}

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -141,8 +141,6 @@ def csv_report(query, delim=None):
 
 
 def is_table_restricted(query, user):
-    if user.is_anonymous():
-        return True
     apps = [a for a in models.get_apps()]
     all_models = []
     model_to_app = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.6.7
+Django>=1.6.7,<1.9.0
 factory-boy==2.6.0
 mock==1.0.1
 six==1.10.0


### PR DESCRIPTION
- Added the functionality to give the user access to particular tables based on django permissions.

Usage:
Set EXPLORER_TABLE_LEVEL_PERMISSION = True in settings.py

In order to give the users access to a particular table, just give them the access to explorer by adding them to a group(s):
EXPLORER_PERMISSION_VIEW = lambda u: u.is_superuser or u.groups.filter(name__in=["SQL_EXPLORER_USERS1", "SQL_EXPLORER_USERS2", "SQL_EXPLORER_USERS3"]).exists()

And give table specific permission to the entire group.

You can also keep one group for user access to explorer and then give table access to the user.

P.S. Right now I've given the access on "change_<model_name>" permission.
