### PR TITLE
Use @xframe_options_sameorigin on schema view so it works with X_FRAME_OPTIONS

### DIFF
--- a/explorer/views.py
+++ b/explorer/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import render_to_response, get_object_or_404
 from django.views.generic.base import View
 from django.views.generic import ListView
 from django.views.generic.edit import CreateView, DeleteView
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_POST, require_GET
 from django.utils.decorators import method_decorator
 from django.core.urlresolvers import reverse_lazy
@@ -127,6 +128,7 @@ def download_csv_from_sql(request):
     return build_download_response(Query(sql=sql, title="Playground", params=url_get_params(request)))
 
 
+@xframe_options_sameorigin
 @change_permission
 @require_GET
 def schema(request):


### PR DESCRIPTION
When using tight settings for Django's [clickjacking protection](https://docs.djangoproject.com/ja/1.9/ref/clickjacking/) such as `X_FRAME_OPTIONS = 'DENY'` the schema view won't work because it is rendered in an iframe.

Since the schema view is limited to GET it's safe to use with the `@xframe_options_sameorigin` decorator to allow it to be rendered in an iframe.