### PR TITLE
Fixed forced lowercasing of queries

### DIFF
--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -75,8 +75,8 @@ def param(name):
 def swap_params(sql, params):
     p = params.items() if params else {}
     for k, v in p:
-        regex = re.compile("\$\$%s(?:\:([^\$]+))?\$\$" % str(k).lower())
-        sql = regex.sub(text_type(v), sql.lower())
+        regex = re.compile("\$\$%s(?:\:([^\$]+))?\$\$" % str(k).lower(), re.I)
+        sql = regex.sub(text_type(v), sql)
     return sql
 
 


### PR DESCRIPTION
Without this patch, explorer lowercases queries although they may be case-sensitive (in my case, there were mixed-case column names within double quotes in PostgreSQL; but probably it also affected queries like `WHERE some_column = 'someMixedCaseValue'`)