### PR TITLE
Fix #212 - eliminate duplicated tables in schema view

### DIFF
--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -45,21 +45,13 @@ def schema_info():
 
     for label, app in apps.app_configs.items():
         if app.name not in app_settings.EXPLORER_SCHEMA_EXCLUDE_APPS:
-            for model_name, model in apps.get_app_config(label).models.items():
+            for model in apps.get_app_config(label).get_models(include_auto_created=True):
                 friendly_model = "%s -> %s" % (app.name, model._meta.object_name)
                 ret.append((
                               friendly_model,
                               model._meta.db_table,
                               [_format_field(f) for f in model._meta.fields]
                           ))
-
-                # Do the same thing for many_to_many fields. These don't show up in the field list of the model
-                # because they are stored as separate "through" relations and have their own tables
-                ret += [(
-                           friendly_model,
-                           m2m.rel.through._meta.db_table,
-                           [_format_field(f) for f in m2m.rel.through._meta.fields]
-                        ) for m2m in model._meta.many_to_many]
 
     return sorted(ret, key=lambda t: t[1])
 


### PR DESCRIPTION
This fixes the duplicate table issue. 

There was a chunk of code that was left over from django 1.6 support. In django 1.6, `django.db.models.get_models` was used without passing `include_auto_created=True`. So some extra code was needed to include the `ManyToMany` tables. Then, when django 1.7 support was added, `AppConfig.models` was used directly, which included all tables.

My fix simply uses the correct `AppConfig.get_models(include_auto_created=True)` method. The extra chunk of code to include `ManyToMany` tables is no longer needed since that would produce duplicate results.