### PR TITLE
fix #213 - query log table overlapping columns

### DIFF
--- a/explorer/static/explorer/explorer.css
+++ b/explorer/static/explorer/explorer.css
@@ -10,10 +10,6 @@
     transition: height 0.01s ease;
 }
 
-.query-list {
-    table-layout: fixed;
-}
-
 .rows-input {
     text-align: center;
     width: 40px;
@@ -33,6 +29,7 @@
 
 .log-sql {
     word-wrap: break-word;
+    white-space: normal !important;
 }
 
 .list {

--- a/explorer/templates/explorer/base.html
+++ b/explorer/templates/explorer/base.html
@@ -47,13 +47,15 @@
         </div>
     </div>
     {% block sql_explorer_footer %}
-        <div class="row">
-          <div class="col-md-12 text-center">
-                <p class="text-muted">
-                    Powered by <a href="https://www.github.com/groveco/django-sql-explorer/">django-sql-explorer</a> from
-                    <a href="https://www.grove.co">Grove Collaborative</a>.
-                </p>
-          </div>
+        <div class="container">
+            <div class="row">
+              <div class="col-md-12 text-center">
+                    <p class="text-muted">
+                        Powered by <a href="https://www.github.com/groveco/django-sql-explorer/">django-sql-explorer</a> from
+                        <a href="https://www.grove.co">Grove Collaborative</a>.
+                    </p>
+              </div>
+            </div>
         </div>
     {% endblock %}
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.7.0/underscore-min.js"></script>

--- a/explorer/templates/explorer/querylog_list.html
+++ b/explorer/templates/explorer/querylog_list.html
@@ -10,30 +10,32 @@
 
 {% block sql_explorer_content %}
     <h3>Recent Query Logs - Page {{ page_obj.number }}</h3>
-    <table class="table table-striped query-list"">
-        <thead>
-            <tr>
-                <th>Run At</th>
-                <th>Run By</th>
-                <th>Duration</th>
-                <th width="33%">SQL</th>
-                <th>Query ID</th>
-                <th>Playground</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for object in recent_logs %}
-            <tr>
-                <td>{{ object.run_at|date:"SHORT_DATETIME_FORMAT" }}</td>
-                <td>{{ object.run_by_user.email }}</td>
-                <td>{{ object.duration|floatformat:2 }}ms</td>
-                <td class="log-sql">{{ object.sql }}</td>
-                <td> {% if object.query_id %}<a href="{% url "query_detail" object.query_id %}">Query {{ object.query_id }}</a>{% elif object.is_playground %}Playground{% else %}--{% endif %}</td>
-                <td><a href="{% url "explorer_playground" %}?querylog_id={{ object.id }}">Open</a></td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    <div class="table-responsive">
+        <table class="table table-striped query-list">
+            <thead>
+                <tr>
+                    <th>Run At</th>
+                    <th>Run By</th>
+                    <th>Duration</th>
+                    <th width="33%">SQL</th>
+                    <th>Query ID</th>
+                    <th>Playground</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for object in recent_logs %}
+                <tr>
+                    <td>{{ object.run_at|date:"SHORT_DATETIME_FORMAT" }}</td>
+                    <td>{{ object.run_by_user.email }}</td>
+                    <td>{{ object.duration|floatformat:2 }}ms</td>
+                    <td class="log-sql">{{ object.sql }}</td>
+                    <td> {% if object.query_id %}<a href="{% url "query_detail" object.query_id %}">Query {{ object.query_id }}</a>{% elif object.is_playground %}Playground{% else %}--{% endif %}</td>
+                    <td><a href="{% url "explorer_playground" %}?querylog_id={{ object.id }}">Open</a></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
     {% if is_paginated %}
         <div class="pagination">
             <span class="page-links">


### PR DESCRIPTION
The main fix I did here was remove the `table-layout: fixed` css style. That was causing columns to overlap.

I also added the bootstrap `.table-responsive` div to make the table scroll horizontally when on small screens, rather than being truncated on the right.

Lastly, I added a `.container` div around the footer so that the body content would not extend past the browser window, causing an ugly gap on the right side of the window.