### PR TITLE
Fix #215 - schema view overlap

### DIFF
--- a/explorer/static/explorer/explorer.css
+++ b/explorer/static/explorer/explorer.css
@@ -104,3 +104,7 @@ span.sort {
 .pvtAxisContainer, .pvtVals {
     border-color: #ddd;
 }
+
+#schema_frame {
+    width: 100%;
+}

--- a/explorer/templates/explorer/base.html
+++ b/explorer/templates/explorer/base.html
@@ -40,11 +40,13 @@
               </div>
             </div>
         {% endblock %}
-        <div class="container">
-          <div class="starter-template">
-          {% block sql_explorer_content %}{% endblock %}
+        {% block sql_explorer_content_wrapper %}
+          <div class="container">
+            <div class="starter-template">
+            {% block sql_explorer_content %}{% endblock %}
+            </div>
           </div>
-        </div>
+        {% endblock sql_explorer_content_wrapper %}
     </div>
     {% block sql_explorer_footer %}
         <div class="row">

--- a/explorer/templates/explorer/schema.html
+++ b/explorer/templates/explorer/schema.html
@@ -1,7 +1,7 @@
 {% extends "explorer/base.html" %}
 
 {% block sql_explorer_navbar %}{% endblock %}
-{% block sql_explorer_content %}
+{% block sql_explorer_content_wrapper %}
 
     <h4 class="text-center">Schema</h4>
     <div id="tables">
@@ -15,19 +15,21 @@
                         <div class="panel-heading">
                             <small class="text-muted app">{{ m.0 }}</small><h4 class="name panel-title">{{ m.1 }}</h4>
                         </div>
-                        <table class="table table-condensed table-hover">
-                            <thead>
-                            </thead>
-                            <tbody>
-                                {% for c in m.2 %}
-                                <tr>
-                                    <td width="50%"><code>{{ c.0 }}</code></td>
-                                    <!-- This will show the type of the column as well -->
-                                    <td width="50%" class="text-muted"><small>{{ c.1 }}</small></td>
-                                </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+                        <div class="table-responsive">
+                            <table class="table table-condensed table-hover">
+                                <thead>
+                                </thead>
+                                <tbody>
+                                    {% for c in m.2 %}
+                                    <tr>
+                                        <td width="50%"><code>{{ c.0 }}</code></td>
+                                        <!-- This will show the type of the column as well -->
+                                        <td width="50%" class="text-muted"><small>{{ c.1 }}</small></td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </li>
             {% endfor %}


### PR DESCRIPTION
This fixes a few style issues with the schema sidebar. I added `.table-responsive` divs to the schema tables to scroll horizontally if they are too wide. Also fixed some spacing issues with the iframe itself.