### PR TITLE
Fix #211 - save schema open status in cookie, other schema opening fixes

### DIFF
--- a/explorer/static/explorer/explorer.js
+++ b/explorer/static/explorer/explorer.js
@@ -32,6 +32,10 @@ function ExplorerEditor(queryId, dataUrl) {
         document.getElementById('id_sql').classList.add('changed-input');
     });
     this.bind();
+
+    if($.cookie('schema_sidebar_open') == 1){
+        this.showSchema.call($("#show_schema_button"));
+    }
 }
 
 ExplorerEditor.prototype.getParams = function() {
@@ -106,27 +110,32 @@ ExplorerEditor.prototype.showRows = function() {
     $form.submit();
 };
 
-ExplorerEditor.prototype.bind = function() {
-    $("#show_schema_button").click(function() {
-        $("#schema_frame").attr('src', '../schema/');
-        $("#query_area").addClass("col-md-9");
-        var schema$ = $("#schema");
-        schema$.addClass("col-md-3");
-        schema$.show();
-        $(this).hide();
-        $("#hide_schema_button").show();
-        return false;
-    });
+ExplorerEditor.prototype.showSchema = function() {
+    $("#schema_frame").attr('src', '../schema/');
+    $("#query_area").removeClass("col-md-12").addClass("col-md-9");
+    var schema$ = $("#schema");
+    schema$.addClass("col-md-3");
+    schema$.show();
+    $(this).hide();
+    $("#hide_schema_button").show();
+    $.cookie('schema_sidebar_open', 1);
+    return false;
+};
 
-    $("#hide_schema_button").click(function() {
-        $("#query_area").removeClass("col-md-9");
-        var schema$ = $("#schema");
-        schema$.removeClass("col-md-3");
-        schema$.hide();
-        $(this).hide();
-        $("#show_schema_button").show();
-        return false;
-    });
+ExplorerEditor.prototype.hideSchema = function() {
+    $("#query_area").removeClass("col-md-9").addClass("col-md-12");
+    var schema$ = $("#schema");
+    schema$.removeClass("col-md-3");
+    schema$.hide();
+    $(this).hide();
+    $("#show_schema_button").show();
+    $.cookie('schema_sidebar_open', 0);
+    return false;
+};
+
+ExplorerEditor.prototype.bind = function() {
+    $("#show_schema_button").click(this.showSchema);
+    $("#hide_schema_button").click(this.hideSchema);
 
     $("#format_button").click(function(e) {
         e.preventDefault();
@@ -173,7 +182,7 @@ ExplorerEditor.prototype.bind = function() {
         }
         this.$form.attr('action', url);
     }.bind(this));
-    
+
     $(".download-query-button").click(function(e) {
         var url = '../download?format=' + $(e.target).data('format');
         var params = this.getParams();

--- a/explorer/templates/explorer/query.html
+++ b/explorer/templates/explorer/query.html
@@ -13,93 +13,89 @@
 
 {% block sql_explorer_content %}
 <div class="row">
-    <div id="query_area" class="query-area">
-        <div class="col-md-8 col-sm-12">
-            <h2>{% if query %}{{ query.title }}{% if shared %}<small>&nbsp;&nbsp;shared</small>{% endif %}{% else %}New Query{% endif %}</h2>
-        </div>
+    <div id="query_area" class="query-area col-md-12">
+        <h2>{% if query %}{{ query.title }}{% if shared %}<small>&nbsp;&nbsp;shared</small>{% endif %}{% else %}New Query{% endif %}</h2>
         {% if query %}
-            <div class="col-md-4 col-sm-12 text-right">
+            <div class="text-right">
                 <a href="{% url "explorer_logs" %}?query_id={{ query.id }}"><h2 class="small">History</h2></a>
             </div>
         {% endif %}
-        <div class="col-md-12">
-            {% if message %}
-                <div class="alert alert-info">{{ message }}</div>
+        {% if message %}
+            <div class="alert alert-info">{{ message }}</div>
+        {% endif %}
+        <div>
+            {% if query %}
+                <form role="form" class="form-horizontal" action="{% url "query_detail" query.id %}" method="post" id="editor">{% csrf_token %}
+            {% else %}
+                <form role="form" class="form-horizontal" action="{% url "query_create" %}" method="post" id="editor">{% csrf_token %}
             {% endif %}
-            <div>
-                {% if query %}
-                    <form role="form" class="form-horizontal" action="{% url "query_detail" query.id %}" method="post" id="editor">{% csrf_token %}
-                {% else %}
-                    <form role="form" class="form-horizontal" action="{% url "query_create" %}" method="post" id="editor">{% csrf_token %}
+                {% if error %}
+                    <div class="alert alert-danger">{{ error|escape }}</div>
                 {% endif %}
-                    {% if error %}
-                        <div class="alert alert-danger">{{ error|escape }}</div>
-                    {% endif %}
-                    {{ form.non_field_errors }}
-                    <div class="form-group">
-                        {% if form.title.errors %}{% for error in form.title.errors %}
-                            <div class="alert alert-danger">{{ error|escape }}</div>
-                        {% endfor %}{% endif %}
-                        <label for="id_title" class="col-sm-2 control-label">Title</label>
-                        <div class="col-sm-10">
-                            <input class="form-control" id="id_title" maxlength="255" name="title" type="text" {% if not can_change %}disabled{% endif %} value="{{ form.title.value|default_if_none:"" }}" />
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        {% if form.description.errors %}
-                            <div class="alert alert-danger">{{ form.description.errors }}</div>
-                        {% endif %}
-                        <label for="id_title" class="col-sm-2 control-label">Description</label>
-                        <div class="col-sm-10">
-                            <textarea class="form-control" cols="40" id="id_description" name="description" {% if not can_change %}disabled{% endif %} rows="2">{{ form.description.value|default_if_none:"" }}</textarea>
-                        </div>
-                    </div>
-                    {% if query %}
-                        <div class="form-group">
-                            {% if form.created_by_user.errors %}
-                                <div class="alert alert-danger">{{ form.created_by_user.errors }}</div>
-                            {% endif %}
-                            <label for="id_title" class="col-sm-2 control-label">Created By</label>
-                            <div class="col-sm-10">
-                                <span class="form-control" disabled id="id_created_by_user_label" maxlength="255" name="created_by_user_label">{{ form.created_by_user_email }}</span>
-                                <input type="hidden" id="id_created_by_user" name="created_by_user" value="{{ form.created_by_user_id }}" />
-                            </div>
-                        </div>
-                    {% endif %}
-                    {% if form.sql.errors %}{% for error in form.sql.errors %}
+                {{ form.non_field_errors }}
+                <div class="form-group">
+                    {% if form.title.errors %}{% for error in form.title.errors %}
                         <div class="alert alert-danger">{{ error|escape }}</div>
                     {% endfor %}{% endif %}
-                    <div class="panel panel-default sql-panel">
-                        <div class="panel-heading">
-                            <span class="panel-title">SQL</span>
-                        </div>
-                        <div class="panel-content">
-                            <textarea class="form-control" {% if not can_change %} disabled {% endif %} cols="40" id="id_sql" name="sql" rows="20">{{ form.sql.value|default_if_none:"" }}</textarea>
-                        </div>
-                        {% if params %}
-                          {% include 'explorer/params.html' %}
-                        {% endif %}
+                    <label for="id_title" class="col-sm-2 control-label">Title</label>
+                    <div class="col-sm-10">
+                        <input class="form-control" id="id_title" maxlength="255" name="title" type="text" {% if not can_change %}disabled{% endif %} value="{{ form.title.value|default_if_none:"" }}" />
                     </div>
+                </div>
+                <div class="form-group">
+                    {% if form.description.errors %}
+                        <div class="alert alert-danger">{{ form.description.errors }}</div>
+                    {% endif %}
+                    <label for="id_title" class="col-sm-2 control-label">Description</label>
+                    <div class="col-sm-10">
+                        <textarea class="form-control" cols="40" id="id_description" name="description" {% if not can_change %}disabled{% endif %} rows="2">{{ form.description.value|default_if_none:"" }}</textarea>
+                    </div>
+                </div>
+                {% if query %}
                     <div class="form-group">
-                        <div class="text-center">
-                            <div class="btn-group">
-                                {% if can_change %}
-                                    <input type="submit" value="Save & Run" class="btn btn-default" id="save_button" />
-                                    {% if query %}
-                                         <input type="submit" value="Open in Playground" class="btn btn-default" id="playground_button"/>
-                                    {%  endif %}
-                                    <button type="button" class="btn btn-default" id="show_schema_button">Show Schema</button>
-                                    <button type="button" class="btn btn-default" id="hide_schema_button" style="display: none;">Hide Schema</button>
-                                    <button type="button" class="btn btn-default" id="format_button">Format</button>
-                                {% else %}
-                                    <input type="submit" value="Refresh" class="btn btn-default" id="refresh_button" />
-                                {% endif %}
-                            </div>
+                        {% if form.created_by_user.errors %}
+                            <div class="alert alert-danger">{{ form.created_by_user.errors }}</div>
+                        {% endif %}
+                        <label for="id_title" class="col-sm-2 control-label">Created By</label>
+                        <div class="col-sm-10">
+                            <span class="form-control" disabled id="id_created_by_user_label" maxlength="255" name="created_by_user_label">{{ form.created_by_user_email }}</span>
+                            <input type="hidden" id="id_created_by_user" name="created_by_user" value="{{ form.created_by_user_id }}" />
                         </div>
                     </div>
-                    {% export_buttons query %}
-                </form>
-            </div>
+                {% endif %}
+                {% if form.sql.errors %}{% for error in form.sql.errors %}
+                    <div class="alert alert-danger">{{ error|escape }}</div>
+                {% endfor %}{% endif %}
+                <div class="panel panel-default sql-panel">
+                    <div class="panel-heading">
+                        <span class="panel-title">SQL</span>
+                    </div>
+                    <div class="panel-content">
+                        <textarea class="form-control" {% if not can_change %} disabled {% endif %} cols="40" id="id_sql" name="sql" rows="20">{{ form.sql.value|default_if_none:"" }}</textarea>
+                    </div>
+                    {% if params %}
+                      {% include 'explorer/params.html' %}
+                    {% endif %}
+                </div>
+                <div class="form-group">
+                    <div class="text-center">
+                        <div class="btn-group">
+                            {% if can_change %}
+                                <input type="submit" value="Save & Run" class="btn btn-default" id="save_button" />
+                                {% if query %}
+                                     <input type="submit" value="Open in Playground" class="btn btn-default" id="playground_button"/>
+                                {%  endif %}
+                                <button type="button" class="btn btn-default" id="show_schema_button">Show Schema</button>
+                                <button type="button" class="btn btn-default" id="hide_schema_button" style="display: none;">Hide Schema</button>
+                                <button type="button" class="btn btn-default" id="format_button">Format</button>
+                            {% else %}
+                                <input type="submit" value="Refresh" class="btn btn-default" id="refresh_button" />
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+                {% export_buttons query %}
+            </form>
         </div>
     </div>
     <div id="schema" style="display: none;">


### PR DESCRIPTION
This PR adds support to "save" the state of the schema side bar in a cookie, so that the next time you load the page, it will remain open (or closed).

I also did some other cleanup related to opening the schema sidebar. There was some incorrect bootstrap grid structure.