### PR TITLE
Fix #210 - fix pivot bookmark bug

### DIFF
--- a/explorer/static/explorer/explorer.js
+++ b/explorer/static/explorer/explorer.js
@@ -231,9 +231,13 @@ ExplorerEditor.prototype.bind = function() {
     if (!pivotState) {
         pivotState = {onRefresh: this.savePivotState};
     } else {
-        pivotState = JSON.parse(atob(pivotState.substr(1)));
-        pivotState['onRefresh'] = this.savePivotState;
-        navToPivot = true;
+        try {
+            pivotState = JSON.parse(atob(pivotState.substr(1)));
+            pivotState['onRefresh'] = this.savePivotState;
+            navToPivot = true;
+        } catch(e) {
+            pivotState = {onRefresh: this.savePivotState};
+        }
     }
 
     $(".pivot-table").pivotUI(this.$table, pivotState);


### PR DESCRIPTION
Fixes #210. This just wraps the pivot bookmark parsing in a try catch. Which makes chrome work again.