### PR TITLE
Schema helper improvements

### DIFF
--- a/explorer/static/explorer/explorer.css
+++ b/explorer/static/explorer/explorer.css
@@ -105,3 +105,27 @@ span.sort {
 #schema_frame {
     width: 100%;
 }
+
+.schema-header {
+    cursor: pointer;
+}
+.insertable {
+    cursor: default;
+}
+
+.CodeMirror-lines .inserted {
+    animation: inserted-pulse 700ms;
+}
+
+@keyframes inserted-pulse {
+    0% {
+        background-color: #f9f2f4;
+        color: #c7254e;
+        font-weight: bold;
+    }
+    100% {
+        background-color: transparent;
+        color: inherit;
+        font-weight: normal;
+    }
+}

--- a/explorer/static/explorer/explorer.js
+++ b/explorer/static/explorer/explorer.js
@@ -137,6 +137,34 @@ ExplorerEditor.prototype.bind = function() {
     $("#show_schema_button").click(this.showSchema);
     $("#hide_schema_button").click(this.hideSchema);
 
+    var editor = this.editor;
+    $("#schema_frame").on('load', function(){
+        var insertables = $(this).contents().find('.insertable');
+        insertables.dblclick(function(e){
+            var text = $(this).html();
+            editor.replaceSelection(text);
+            var cursor = editor.getCursor();
+            var marker = editor.markText(
+                CodeMirror.Pos(cursor.line, cursor.ch - text.length),
+                cursor,
+                {'className': 'inserted'}
+            );
+            setTimeout(function(){
+                marker.clear();
+            }, 350);
+            editor.focus();
+            e.preventDefault();
+            return false;
+        });
+
+        insertables.click(function(e){
+            e.preventDefault();
+            return false;
+        });
+        insertables.tooltip({title:'Double click to insert'});
+        insertables.disableSelection();
+    });
+
     $("#format_button").click(function(e) {
         e.preventDefault();
         this.formatSql();

--- a/explorer/static/explorer/explorer.js
+++ b/explorer/static/explorer/explorer.js
@@ -231,9 +231,13 @@ ExplorerEditor.prototype.bind = function() {
     if (!pivotState) {
         pivotState = {onRefresh: this.savePivotState};
     } else {
-        pivotState = JSON.parse(atob(pivotState.substr(1)));
-        pivotState['onRefresh'] = this.savePivotState;
-        navToPivot = true;
+        try {
+            pivotState = JSON.parse(atob(pivotState.substr(1)));
+            pivotState['onRefresh'] = this.savePivotState;
+            navToPivot = true;
+        } catch(e) {
+            pivotState = {onRefresh: this.savePivotState};
+        }
     }
 
     $(".pivot-table").pivotUI(this.$table, pivotState);

--- a/explorer/templates/explorer/schema.html
+++ b/explorer/templates/explorer/schema.html
@@ -8,21 +8,30 @@
         <p>
           <input class="form-control search" placeholder="Search" />
         </p>
+        <div class="row">
+            <div class="col-xs-6 text-center">
+                <a class="btn btn-link" id="collapse_all">Collapse All</a>
+            </div>
+            <div class="col-xs-6 text-center">
+                <a class="btn btn-link" id="expand_all">Expand All</a>
+            </div>
+        </div>
         <ul class="list">
             {% for m in schema %}
                 <li>
                     <div class="panel panel-default">
-                        <div class="panel-heading">
-                            <small class="text-muted app">{{ m.0 }}</small><h4 class="name panel-title">{{ m.1 }}</h4>
+                        <div class="panel-heading schema-header">
+                            <small class="text-muted app">{{ m.0 }}</small><br/>
+                            <h4 class="name panel-title insertable" style="display: inline-block">{{ m.1 }}</h4>
                         </div>
-                        <div class="table-responsive">
+                        <div class="table-responsive schema-table">
                             <table class="table table-condensed table-hover">
                                 <thead>
                                 </thead>
                                 <tbody>
                                     {% for c in m.2 %}
                                     <tr>
-                                        <td width="50%"><code>{{ c.0 }}</code></td>
+                                        <td width="50%"><code class="insertable">{{ c.0 }}</code></td>
                                         <!-- This will show the type of the column as well -->
                                         <td width="50%" class="text-muted"><small>{{ c.1 }}</small></td>
                                     </tr>
@@ -50,6 +59,16 @@
             handlers: { 'updated': [SearchFocus] }
         };
         var tableList = new List('tables', options);
+
+        $('#collapse_all').click(function(){
+            $('.schema-table').hide();
+        });
+        $('#expand_all').click(function(){
+            $('.schema-table').show();
+        });
+        $('.schema-header').click(function(){
+            $(this).parent().find('.schema-table').toggle();
+        });
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
This fixes #223 and #214.

Allows users to expand or collapse each table in the schema helper as well as expand or collapse all of the tables at once.

Allows users to double click on column and table names to automatically insert the column/table name into the sql editor at the cursor location (or replace the currently selected text).

Let me know if you like this, or if I need to change anything.