### PR TITLE
README: clarify the dependency on a Django app

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Django SQL Explorer
 
 SQL Explorer aims to make the flow of data between people fast, simple, and confusion-free.
 
-Quickly write and share SQL queries in a simple, usable SQL editor, preview the results in the browser, share links to download CSV files, and keep the information flowing!
+Quickly write and share SQL queries for any Django app in a simple, usable SQL editor, preview the results in the browser, share links to download CSV files, and keep the information flowing!
 
 Explorer values simplicity, intuitive use, unobtrusiveness, stability, and the principle of least surprise.
 


### PR DESCRIPTION
As a newcomer coming from a HN discussion, looking at the description and a few lines of README, it is easy to misunderstand the project as a *generic* SQL Explorer that happens to run on Django, as opposed to what it is: an SQL Explorer for Django apps, that happens to run on Django too. README clarifies later in the Requirements section, but the clearer the better, no?

I had to read at the bottom of the HN comment thread the author commenting that *it is tied to Django and expects to be querying a Django application DB. I would actually love to remove this requirement though, and have it just be SQL Explorer* to grasp it.

This little addition aims to fix that, and may I suggest to precise the 1-liner from *Easily share data across your company via SQL queries. From Grove Collab.* to *Easily share data across your company via SQL queries on any Django app. From Grove Collab.* ?