### PR TITLE
fullscreen view of query results

### DIFF
--- a/explorer/static/explorer/explorer.js
+++ b/explorer/static/explorer/explorer.js
@@ -171,7 +171,9 @@ ExplorerEditor.prototype.bind = function() {
     }.bind(this));
 
     $("#rows").keyup(function() {
-        $("#fullscreen").attr('href', '../' + this.queryId + '/?fullscreen=1&rows=' + $("#rows").val());
+        var curUrl = $("#fullscreen").attr('href');
+        var newUrl = curUrl.replace(/rows=\d+/, 'rows=' + $("#rows").val());
+        $("#fullscreen").attr('href', newUrl);
     }.bind(this));
 
     $("#save_button").click(function() {

--- a/explorer/static/explorer/explorer.js
+++ b/explorer/static/explorer/explorer.js
@@ -170,6 +170,10 @@ ExplorerEditor.prototype.bind = function() {
         this.formatSql();
     }.bind(this));
 
+    $("#rows").keyup(function() {
+        $("#fullscreen").attr('href', '../' + this.queryId + '/?fullscreen=1&rows=' + $("#rows").val());
+    }.bind(this));
+
     $("#save_button").click(function() {
         var params = this.getParams(this);
         if(params) {

--- a/explorer/templates/explorer/fullscreen.html
+++ b/explorer/templates/explorer/fullscreen.html
@@ -1,0 +1,40 @@
+{% load staticfiles %}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SQL Explorer{% if query %} - {{ query.title }}{% elif title %} - {{ title }}{% endif %}</title>
+
+    <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="{% static 'explorer/explorer.css' %}" />
+
+</head>
+
+<body>
+  <h2>{% if query %}{{ query.title }}{% if shared %}<small>&nbsp;&nbsp;shared</small>{% endif %}{% else %}New Query{% endif %}</h2>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        {% for h in headers %}
+          <th>{{ h }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody class="list">
+      {% if data %}
+        {% for row in data %}
+          <tr class="data-row">
+            {% for i in row %}
+              <td>{% autoescape off %}{{ i }}{% endautoescape %}</td>
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      {% else %}
+        <tr class="text-center"><td colspan="{{ headers|length }}">Empty Resultset</td></tr>
+      {% endif %}
+    </tbody>
+  </table>
+</body>
+</html>

--- a/explorer/templates/explorer/preview_pane.html
+++ b/explorer/templates/explorer/preview_pane.html
@@ -18,15 +18,21 @@
                                 <div class="col-md-6 text-right">
                                   <span class="row-control">
                                       {% if rows > total_rows %}
-                                          Showing {{ total_rows }} of {{ total_rows }} total rows.
+                                          Showing <input class="rows-input" type="text" name="rows" id="rows" value="{{ total_rows }}" />
                                       {% else %}
-                                          First <input class="rows-input" type="text" name="rows" id="rows" value="{{ rows }}" /> of {{ total_rows }} total rows.
+                                          First <input class="rows-input" type="text" name="rows" id="rows" value="{{ rows }}" />
                                       {% endif %}
+                                      of {{ total_rows }} total rows.
                                   </span>
                                   <span>
-                                    <a id="fullscreen" href="./?fullscreen=1" target="_blank" title="Fullscreen results">
-                                      <i class="glyphicon glyphicon-resize-full"></i>
-                                    </a>
+                                    <small>
+                                    {%  if query.id %}
+                                      <a id="fullscreen" href="./?fullscreen=1&rows={{ rows }}" target="_blank" title="Fullscreen results">
+                                    {% elif ql_id %}
+                                      <a id="fullscreen" href="./?querylog_id={{ ql_id }}&fullscreen=1&rows={{ rows }}" target="_blank" title="Fullscreen results">
+                                    {% endif %}
+                                        <i class="glyphicon glyphicon-resize-full"></i>
+                                      </a></small>
                                   </span>
                                 </div>
                               </div>

--- a/explorer/templates/explorer/preview_pane.html
+++ b/explorer/templates/explorer/preview_pane.html
@@ -24,7 +24,9 @@
                                       {% endif %}
                                   </span>
                                   <span>
-                                    <a id="fullscreen" href="./?fullscreen=1" target="_blank"><i class="glyphicon glyphicon-resize-full"></i></a>
+                                    <a id="fullscreen" href="./?fullscreen=1" target="_blank" title="Fullscreen results">
+                                      <i class="glyphicon glyphicon-resize-full"></i>
+                                    </a>
                                   </span>
                                 </div>
                               </div>

--- a/explorer/templates/explorer/preview_pane.html
+++ b/explorer/templates/explorer/preview_pane.html
@@ -23,6 +23,9 @@
                                           First <input class="rows-input" type="text" name="rows" id="rows" value="{{ rows }}" /> of {{ total_rows }} total rows.
                                       {% endif %}
                                   </span>
+                                  <span>
+                                    <a id="fullscreen" href="./?fullscreen=1" target="_blank"><i class="glyphicon glyphicon-resize-full"></i></a>
+                                  </span>
                                 </div>
                               </div>
                             </div>

--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -208,6 +208,11 @@ class TestQueryDetailView(TestCase):
         # Feels fragile, but nor sure how else to access the called-with params of .execute
         self.assertEqual(conn.cursor.mock_calls[1][1][0], "select 1;")
 
+    def test_fullscreen(self):
+        query = SimpleQueryFactory(sql="select 1;")
+        resp = self.client.get(reverse("query_detail", kwargs={'query_id': query.id}) + '?fullscreen=1')
+        self.assertTemplateUsed(resp, 'explorer/fullscreen.html')
+
 
 class TestDownloadView(TestCase):
     def setUp(self):
@@ -310,6 +315,11 @@ class TestQueryPlayground(TestCase):
         resp = self.client.post(reverse("explorer_playground"), {'sql': "select 'delete'"})
         self.assertTemplateUsed(resp, 'explorer/play.html')
         self.assertContains(resp, MSG_FAILED_BLACKLIST % '')
+
+    def test_fullscreen(self):
+        query = SimpleQueryFactory(sql="")
+        resp = self.client.get('%s?query_id=%s&fullscreen=1' % (reverse("explorer_playground"), query.id))
+        self.assertTemplateUsed(resp, 'explorer/fullscreen.html')
 
 
 class TestCSVFromSQL(TestCase):

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -158,6 +158,10 @@ def url_get_show(request):
     return bool(get_int_from_request(request, 'show', 1))
 
 
+def url_get_fullscreen(request):
+    return bool(get_int_from_request(request, 'fullscreen', 0))
+
+
 def url_get_params(request):
     return get_params_from_request(request)
 

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -265,14 +265,14 @@ class PlayQueryView(ExplorerContextMixin, View):
     def get(self, request):
         if url_get_query_id(request):
             query = get_object_or_404(Query, pk=url_get_query_id(request))
-            return self.render_with_sql(request, query, run_query=False)
+            return self.render_with_sql(request.user, query, run_query=False)
 
         if url_get_log_id(request):
             log = get_object_or_404(QueryLog, pk=url_get_log_id(request))
             query = Query(sql=log.sql, title="Playground")
-            return self.render_with_sql(request, query)
+            return self.render_with_sql(request.user, query)
 
-        return self.render(request)
+        return self.render()
 
     def post(self, request):
         sql = request.POST.get('sql')
@@ -283,12 +283,19 @@ class PlayQueryView(ExplorerContextMixin, View):
         run_query = not bool(error) if show else False
         return self.render_with_sql(request, query, run_query=run_query, error=error)
 
-    def render(self, request):
+    def render(self):
         return self.render_template('explorer/play.html', {'title': 'Playground'})
 
-    def render_with_sql(self, request, query, run_query=True, error=None):
-        return self.render_template('explorer/play.html', query_viewmodel(request.user, query, title="Playground"
-                                                                          , run_query=run_query, error=error))
+    def render_with_sql(self, user, query, run_query=True, error=None):
+        rows = url_get_rows(request),
+        fullscreen = url_get_fullscreen(request)
+        template = 'fullscreen' if fullscreen else 'play'
+        return self.render_template('explorer/%s.html' % template, query_viewmodel(user,
+                                                                                   query,
+                                                                                   title="Playground",
+                                                                                   run_query=run_query,
+                                                                                   error=error,
+                                                                                   rows=rows))
 
 
 class QueryView(ExplorerContextMixin, View):

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -265,12 +265,12 @@ class PlayQueryView(ExplorerContextMixin, View):
     def get(self, request):
         if url_get_query_id(request):
             query = get_object_or_404(Query, pk=url_get_query_id(request))
-            return self.render_with_sql(request.user, query, run_query=False)
+            return self.render_with_sql(request, query, run_query=False)
 
         if url_get_log_id(request):
             log = get_object_or_404(QueryLog, pk=url_get_log_id(request))
             query = Query(sql=log.sql, title="Playground")
-            return self.render_with_sql(request.user, query)
+            return self.render_with_sql(request, query)
 
         return self.render()
 
@@ -286,11 +286,11 @@ class PlayQueryView(ExplorerContextMixin, View):
     def render(self):
         return self.render_template('explorer/play.html', {'title': 'Playground'})
 
-    def render_with_sql(self, user, query, run_query=True, error=None):
-        rows = url_get_rows(request),
+    def render_with_sql(self, request, query, run_query=True, error=None):
+        rows = url_get_rows(request)
         fullscreen = url_get_fullscreen(request)
         template = 'fullscreen' if fullscreen else 'play'
-        return self.render_template('explorer/%s.html' % template, query_viewmodel(user,
+        return self.render_template('explorer/%s.html' % template, query_viewmodel(request.user,
                                                                                    query,
                                                                                    title="Playground",
                                                                                    run_query=run_query,


### PR DESCRIPTION
Places a link on the query preview to open the preview pane in a 'full screen' view in a new tab, suitable to printing results. Basic implementation for now. In addition to be useful on occasion to go fullscreen to look through data, it will addres #207 via a side door; it's hard to reliably export results to PDF, so instead I'm going to close that issue, and folks can print-to-pdf form the fullscreen view if that functionality is needed.

Checklist for release:

- [ ] test coverage
- [ ] handle playground queries

Future enhancement ideas:

- allow easy printing of pivot table results as well
- some JS goodness (e.g. column sorting) even in the fullscreen view