### PR TITLE
Query parameter authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,12 @@ Features
     - If a query is taking a long time to run (perhaps timing out) and you want to get in there to optimize it, go to /query/123/?show=0. You'll see the normal query detail page, but the query won't execute.
     - Set env vars for EXPLORER_TOKEN_AUTH_ENABLED=TRUE and EXPLORER_TOKEN=<SOME TOKEN> and you have an instant data API. Just:
 
-    ``curl --header "X-API-TOKEN: <TOKEN>" https://www.your-site.com/explorer/<QUERY_ID>/stream?format=csv``
+      ``curl --header "X-API-TOKEN: <TOKEN>" https://www.your-site.com/explorer/<QUERY_ID>/stream?format=csv``
+    
+      You can also pass the token with a query parameter like this:
+      
+      ``curl https://www.your-site.com/explorer/<QUERY_ID>/stream?format=csv&token=<TOKEN>``
+      
 
 Install
 =======

--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -158,6 +158,16 @@ class TestQueryDetailView(TestCase):
         self.assertTemplateUsed(resp, 'explorer/query.html')
         self.assertContains(resp, "124")
 
+    def test_token_auth(self):
+        self.client.logout()
+
+        query = SimpleQueryFactory(sql="select 123+1")
+
+        with self.settings(EXPLORER_TOKEN_AUTH_ENABLED=True):
+            resp = self.client.get(reverse("query_detail", kwargs={'query_id': query.id}) + '?token=%s' % EXPLORER_TOKEN)
+        self.assertTemplateUsed(resp, 'explorer/query.html')
+        self.assertContains(resp, "124")
+
     def test_user_query_views(self):
         request = Mock()
 

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -41,7 +41,8 @@ def view_permission(f):
         if not app_settings.EXPLORER_PERMISSION_VIEW(request.user)\
                 and not user_can_see_query(request, kwargs)\
                 and not (app_settings.EXPLORER_TOKEN_AUTH_ENABLED()
-                         and request.META.get('HTTP_X_API_TOKEN') == app_settings.EXPLORER_TOKEN):
+                         and (request.META.get('HTTP_X_API_TOKEN') == app_settings.EXPLORER_TOKEN
+                              or request.GET.get('token') == app_settings.EXPLORER_TOKEN)):
             return safe_login_prompt(request)
         return f(request, *args, **kwargs)
     return wrap


### PR DESCRIPTION
This PR adds support for authenticating requests with a token in the url:

```
https://example.com/sql-explorer/query/1/?token=hello-world
```

The token is `EXPLORER_TOKEN`, the same as currently used with header based authentication. Query parameter authentication is useful in the cases where clients do not provide access to custom headers.