### PR TITLE
show row numbers

### DIFF
--- a/explorer/static/explorer/explorer.css
+++ b/explorer/static/explorer/explorer.css
@@ -159,3 +159,9 @@ span.sort {
 a#fullscreen {
     padding-left: 1rem;
 }
+
+.counter {
+    display: none;
+    background-color: #ecf0f1;
+    font-family: monospace;
+}

--- a/explorer/static/explorer/explorer.js
+++ b/explorer/static/explorer/explorer.js
@@ -243,6 +243,12 @@ ExplorerEditor.prototype.bind = function() {
         $(".stats-wrapper").show();
         this.$table.floatThead('reflow');
     }.bind(this));
+    
+    $("#counter-toggle").click(function(e) {
+        e.preventDefault();
+        $('.counter').toggle();
+        this.$table.floatThead('reflow');
+    }.bind(this));
 
     $(".sort").click(function(e) {
         var t = $(e.target).data('sort');

--- a/explorer/templates/explorer/preview_pane.html
+++ b/explorer/templates/explorer/preview_pane.html
@@ -13,6 +13,7 @@
                             <div class="panel-heading">
                               <div class="row">
                                 <div class="col-md-6">
+                                  {% if data %}<a title="Show row numbers" id="counter-toggle" href="#">#</a>&nbsp;{% endif %}
                                   <span class="panel-title">Execution time: {{ duration|floatformat:2 }} ms</span>
                                 </div>
                                 <div class="col-md-6 text-right">
@@ -41,12 +42,14 @@
                                 <table class="table table-striped table-hover" id="preview">
                                     <thead class="data-headers">
                                         <tr>
+                                            <th class="preview-header counter"></th>
                                             {% for h in headers %}
                                                 <th class="preview-header"><span class="sort" data-sort="{{ forloop.counter0 }}" data-dir="asc">{{ h }}</span></th>
                                             {% endfor %}
                                         </tr>
                                         <tr class="stats-th">
-                                        {% for h in headers %}
+                                          <th class="counter"></th>
+                                          {% for h in headers %}
                                           <th>
                                             {% if h.summary %}
                                               <i class="stats-expand glyphicon glyphicon-education"></i>
@@ -57,7 +60,7 @@
                                               </div>
                                             {% endif %}
                                           </th>
-                                        {% endfor %}
+                                          {% endfor %}
                                         </tr>
 
                                     </thead>
@@ -65,6 +68,7 @@
                                         {% if data %}
                                             {% for row in data %}
                                             <tr class="data-row">
+                                              <td class="counter">{{ forloop.counter0 }}</td>
                                                 {% for i in row %}
                                                     <td class="{{ forloop.counter0 }}">{% autoescape off %}{{ i }}{% endautoescape %}</td>
                                                 {% endfor %}


### PR DESCRIPTION
Adds a # toggle here:

![image](https://cloud.githubusercontent.com/assets/693700/20584400/114f8074-b1a7-11e6-8538-9b4c4d5d2d1e.png)

That can show row numbers in the results pane:

![image](https://cloud.githubusercontent.com/assets/693700/20584404/29a44c18-b1a7-11e6-9f9d-4205e805c22a.png)

This is a stupid example because the ID field is effectively the same, but this feature can be useful when you need to eyeball how many results meet a certain criteria when the results are sorted. Like, if you have a list of customers sorted by first name -- how many names begin with the letter 'B'? You can now eyeball or compute the answer yourself by examining the line numbers vs. modifying the query or downloading it.

Small feature, but surprisingly useful.