### PR TITLE
Fix invalid HTML in params.html

### DIFF
--- a/explorer/templates/explorer/params.html
+++ b/explorer/templates/explorer/params.html
@@ -5,7 +5,7 @@
       <div class="form-group">
           <label for="{{ k }}_param" class="control-label col-sm-4">{{ k }}:</label>
           <div class="col-sm-7">
-              <input type="text" data-param="{{ k }}" class="param form-control" name="{{ k }}_param" placeholder="parameter" value="{{ v }}" />
+              <input type="text" data-param="{{ k }}" class="param form-control" name="{{ k }}_param" id="{{ k }}_param" placeholder="parameter" value="{{ v }}" />
           </div>
           <div class="col-sm-1"></div>
       </div>


### PR DESCRIPTION
The `for` attribute has to refer to an ID, and there wasn't an ID being set on the input for the parameter.