### PR TITLE
Small fix for Google App Engine

### DIFF
--- a/explorer/exporters.py
+++ b/explorer/exporters.py
@@ -107,7 +107,7 @@ class ExcelExporter(BaseExporter):
         import xlsxwriter
         output = BytesIO()
 
-        wb = xlsxwriter.Workbook(output)
+        wb = xlsxwriter.Workbook(output, {'in_memory': True})
 
         # XLSX writer wont allow sheet names > 31 characters
         # https://github.com/jmcnamara/XlsxWriter/blob/master/xlsxwriter/test/workbook/test_check_sheetname.py


### PR DESCRIPTION
On Google App Engine you get this error, when use Excel Export
Exception Type: NotImplementedError
Exception Value: Only tempfile.TemporaryFile is available for use

With this fix, xlsxwriter use in_memory mode, so all work good