### PR TITLE
Remove unused lambda expressions assigned to "_"

### DIFF
--- a/explorer/actions.py
+++ b/explorer/actions.py
@@ -6,8 +6,6 @@ from wsgiref.util import FileWrapper
 from django.http import HttpResponse
 from explorer.exporters import CSVExporter
 
-_ = lambda x: x
-
 
 def generate_report_action(description="Generate CSV file from SQL query",):
 

--- a/explorer/forms.py
+++ b/explorer/forms.py
@@ -4,8 +4,6 @@ from django.forms.widgets import CheckboxInput
 
 from explorer.models import Query, MSG_FAILED_BLACKLIST
 
-_ = lambda x: x
-
 
 class SqlField(Field):
 
@@ -30,7 +28,7 @@ class SqlField(Field):
 
         if error:
             raise ValidationError(
-                _(error),
+                error,
                 code="InvalidSql"
             )
 

--- a/explorer/tests/test_schema.py
+++ b/explorer/tests/test_schema.py
@@ -3,9 +3,6 @@ from explorer.utils import get_connection
 from explorer import schema
 
 
-_ = lambda x: x
-
-
 class TestSchemaInfo(TestCase):
 
     def tearDown(self):

--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -14,9 +14,6 @@ from explorer.app_settings import EXPLORER_TOKEN
 from mock import Mock, patch
 
 
-_ = lambda x: x
-
-
 class TestQueryListView(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This commit removes several noop lambda expressions assigned to the name
"_". In all but one case, they were unused. In the case where it was
being called, the call was simply removed (the lambda was just returing
the value passed to it, so it was unnecessary).

_('foo') is a common idiom for localization, and my guess is that at
some point some code using that convention was copy/pasted in to this
project, and the lambda was added as a workaround for that function
being missing.