### PR TITLE
Fix duplicate test names

### DIFF
--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -148,7 +148,7 @@ class TestQueryDetailView(TestCase):
         self.assertTemplateUsed(resp, 'explorer/query.html')
         self.assertContains(resp, "124")
 
-    def test_token_auth(self):
+    def test_header_token_auth(self):
         self.client.logout()
 
         query = SimpleQueryFactory(sql="select 123+1")
@@ -158,7 +158,7 @@ class TestQueryDetailView(TestCase):
         self.assertTemplateUsed(resp, 'explorer/query.html')
         self.assertContains(resp, "124")
 
-    def test_token_auth(self):
+    def test_url_token_auth(self):
         self.client.logout()
 
         query = SimpleQueryFactory(sql="select 123+1")


### PR DESCRIPTION
The two token auth related tests had the same name. This commit gives
them unique, descriptive names.