### PR TITLE
Escape strings from the database when rendering

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -2,7 +2,7 @@
 =====
 
 - BREAKING CHANGE: EXPLORER_DATA_EXPORTERS setting is now a list of tuples insead of a dictionary. This only affects you if you have customized this setting. This was to preserve ordering of the export buttons in the UI.
-
+- BREAKING CHANGE: Values from the database are now escaped by default. Disable this behavior (enabling potential XSS attacks) with the EXPLORER_UNSAFE_RENDERING setting.
 
 1.0.0
 =====

--- a/README.rst
+++ b/README.rst
@@ -242,6 +242,7 @@ EXPLORER_S3_SECRET_KEY                  S3 Secret Key for snapshot upload       
 EXPLORER_S3_BUCKET                      S3 Bucket for snapshot upload                                                                                   None
 EXPLORER_FROM_EMAIL                     The default 'from' address when using async report email functionality                                          "django-sql-explorer@example.com"
 EXPLORER_DATA_EXPORTERS                 The export buttons to use. Default includes Excel, so xlsxwriter from optional-requirements.txt is needed       [('csv', 'explorer.exporters.CSVExporter'), ('excel', 'explorer.exporters.ExcelExporter'), ('json', 'explorer.exporters.JSONExporter')]
+EXPLORER_UNSAFE_RENDERING               Disable autoescaping for the rendering of values from the database. Enable this if you like XSS attacks...      False
 ======================================= =============================================================================================================== ================================================================================================================================================
 
 Release Process

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -75,3 +75,5 @@ S3_ACCESS_KEY = getattr(settings, "EXPLORER_S3_ACCESS_KEY", None)
 S3_SECRET_KEY = getattr(settings, "EXPLORER_S3_SECRET_KEY", None)
 S3_BUCKET = getattr(settings, "EXPLORER_S3_BUCKET", None)
 FROM_EMAIL = getattr(settings, 'EXPLORER_FROM_EMAIL', 'django-sql-explorer@example.com')
+
+UNSAFE_RENDERING = getattr(settings, "EXPLORER_UNSAFE_RENDERING", False)

--- a/explorer/templates/explorer/fullscreen.html
+++ b/explorer/templates/explorer/fullscreen.html
@@ -27,7 +27,11 @@
         {% for row in data %}
           <tr class="data-row">
             {% for i in row %}
-              <td>{% autoescape off %}{{ i }}{% endautoescape %}</td>
+              {% if unsafe_rendering %}
+                <td>{% autoescape off %}{{ i }}{% endautoescape %}</td>
+              {% else %}
+                <td>{{ i }}</td>
+              {% endif %}
             {% endfor %}
           </tr>
         {% endfor %}

--- a/explorer/templates/explorer/preview_pane.html
+++ b/explorer/templates/explorer/preview_pane.html
@@ -70,7 +70,11 @@
                                             <tr class="data-row">
                                               <td class="counter">{{ forloop.counter0 }}</td>
                                                 {% for i in row %}
+                                                  {% if unsafe_rendering %}
                                                     <td class="{{ forloop.counter0 }}">{% autoescape off %}{{ i }}{% endautoescape %}</td>
+                                                  {% else %}
+                                                    <td class="{{ forloop.counter0 }}">{{ i }}</td>
+                                                  {% endif %}
                                                 {% endfor %}
                                             </tr>
                                             {% endfor %}

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -361,6 +361,7 @@ def query_viewmodel(user, query, title=None, form=None, message=None, run_query=
         'has_stats': len([h for h in res.headers if h.summary]) if has_valid_results else False,
         'bucket': app_settings.S3_BUCKET,
         'snapshots': query.snapshots if query.snapshot else [],
-        'ql_id': ql.id if ql else None
+        'ql_id': ql.id if ql else None,
+        'unsafe_rendering': app_settings.UNSAFE_RENDERING,
     }
     return ret


### PR DESCRIPTION
Disabling autoescaping is unsafe, and results in an XSS vulnerability if
the attacker is able to control database values which get included in
DSE rendered reports.

This commit enables autoescaping by default, and adds a clearly named
setting to restore the old behavior in case someone was relying on it.

This would address #267