### PR TITLE
Fix delete query bug

### DIFF
--- a/explorer/permissions.py
+++ b/explorer/permissions.py
@@ -19,5 +19,5 @@ def view_permission_list(request):
         or allowed_query_pks(request.user.id)
 
 
-def change_permission(request):
+def change_permission(request, *args, **kwargs):
     return app_settings.EXPLORER_PERMISSION_CHANGE(request.user)


### PR DESCRIPTION
When deleting a query, the web-explorer will request url: `/explorer-admin/1/delete`, then the DeleteView will check if the user has permission to delete a query:
`explorer/views.py` line 73-77
```
    def has_permission(self, request, *args, **kwargs):
        perms = self.get_permission_required()
        handler = getattr(permissions, perms)  # TODO: fix the case when the perms is
                                               # not defined in permissions module.
        return handler(request, *args, **kwargs)
```
You can see here will call `handler(request, *args, **kwargs)`.
But in `permissions.py`, the `change_permission` function is defined as:
```
def change_permission(request):
    return app_settings.EXPLORER_PERMISSION_CHANGE(request.user)
```
It is a bug I think.
this patch fix it.