### PR TITLE
Better emailing

### DIFF
--- a/explorer/exporters.py
+++ b/explorer/exporters.py
@@ -37,11 +37,8 @@ class BaseExporter(object):
             return str(value)
 
     def get_file_output(self, **kwargs):
-        try:
-            res = self.query.execute_query_only()
-            return self._get_output(res, **kwargs)
-        except DatabaseError as e:
-            return StringIO(str(e))
+        res = self.query.execute_query_only()
+        return self._get_output(res, **kwargs)
 
     def _get_output(self, res, **kwargs):
         """

--- a/explorer/static/explorer/query-list.js
+++ b/explorer/static/explorer/query-list.js
@@ -42,7 +42,10 @@ $('body').on('submit', '.email-csv-form', function (e) {
         email: $this.find('[name=email]').val()
       },
       success: function () {
-        $this.closest('td').find('.email-csv').popover('hide');
+        var $el = $this.closest('td');
+        $el.find('.popover-content').html("Ok! The query results will be emailed to you shortly.");
+        var closeSoon = function() { $el.find('.email-csv').popover('hide'); };
+        setTimeout(closeSoon, 2000);
       }
     });
   } else {

--- a/explorer/tasks.py
+++ b/explorer/tasks.py
@@ -4,6 +4,7 @@ import string
 
 from django.core.mail import send_mail
 from django.core.cache import cache
+from django.db import DatabaseError
 
 from explorer import app_settings
 from explorer.exporters import get_exporter_class
@@ -23,13 +24,21 @@ else:
 @task
 def execute_query(query_id, email_address):
     q = Query.objects.get(pk=query_id)
+    send_mail('[SQL Explorer] Your query is running...',
+              '%s is running and should be in your inbox soon!' % q.title,
+              app_settings.FROM_EMAIL,
+              [email_address])
+
     exporter = get_exporter_class('csv')(q)
     random_part = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(20))
-    url = s3_upload('%s.csv' % random_part, exporter.get_file_output())
-
-    subj = '[SQL Explorer] Report "%s" is ready' % q.title
-    msg = 'Download results:\n\r%s' % url
-
+    try:
+        url = s3_upload('%s.csv' % random_part, exporter.get_file_output())
+        subj = '[SQL Explorer] Report "%s" is ready' % q.title
+        msg = 'Download results:\n\r%s' % url
+    except DatabaseError as e:
+        subj = '[SQL Explorer] Error running report %s' % q.title
+        msg = 'Error: %s\nPlease contact an administrator' %  e
+        logger.warning('%s: %s' % (subj, e))
     send_mail(subj, msg, app_settings.FROM_EMAIL, [email_address])
 
 

--- a/explorer/tests/test_tasks.py
+++ b/explorer/tests/test_tasks.py
@@ -20,13 +20,14 @@ class TestTasks(TestCase):
         output = StringIO()
         output.write('a,b,c\r\n1,2,3\r\n')
 
-        self.assertEqual(len(mail.outbox), 1)
-        self.assertIn('[SQL Explorer] Report ', mail.outbox[0].subject)
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertIn('[SQL Explorer] Your query is running', mail.outbox[0].subject)
+        self.assertIn('[SQL Explorer] Report ', mail.outbox[1].subject)
         self.assertEqual(mocked_upload.call_args[0][1].getvalue(), output.getvalue())
         self.assertEqual(mocked_upload.call_count, 1)
 
     @patch('explorer.tasks.s3_upload')
-    def test_async_results_failswith_message(self, mocked_upload):
+    def test_async_results_fails_with_message(self, mocked_upload):
         mocked_upload.return_value = 'http://s3.com/your-file.csv'
 
         q = SimpleQueryFactory(sql='select x from foo;', title="testquery")
@@ -35,9 +36,9 @@ class TestTasks(TestCase):
         output = StringIO()
         output.write('a,b,c\r\n1,2,3\r\n')
 
-        self.assertEqual(len(mail.outbox), 1)
-        self.assertIn('[SQL Explorer] Report ', mail.outbox[0].subject)
-        self.assertEqual(mocked_upload.call_args[0][1].getvalue(), "no such table: foo")
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertIn('[SQL Explorer] Error ', mail.outbox[1].subject)
+        self.assertEqual(mocked_upload.call_count, 0)
 
     @patch('explorer.tasks.s3_upload')
     def test_snapshots(self, mocked_upload):

--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -284,6 +284,14 @@ class TestDownloadView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['content-type'], 'text/csv')
 
+    def test_bad_query_gives_500(self):
+        query = SimpleQueryFactory(sql='bad')
+        url = reverse("download_query", args=[query.pk]) + '?format=csv'
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 500)
+
     def test_download_json(self):
         query = SimpleQueryFactory()
         url = reverse("download_query", args=[query.pk]) + '?format=json'

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -98,7 +98,7 @@ def _export(request, query, download=True):
     except DatabaseError as e:
         msg = "Error executing query %s: %s" % (query.title, e)
         logger.warning(msg)
-        return HttpResponse(msg, status_code=500)
+        return HttpResponse(msg, status=500)
     response = HttpResponse(output, content_type=exporter.content_type)
     if download:
         response['Content-Disposition'] = 'attachment; filename="%s"' % (

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -40,6 +40,8 @@ from explorer.utils import (
 
 from explorer.schema import schema_info
 from explorer import permissions
+import logging
+logger = logging.getLogger(__name__)
 
 
 class ExplorerContextMixin(object):
@@ -91,7 +93,12 @@ def _export(request, query, download=True):
     query.params = url_get_params(request)
     delim = request.GET.get('delim')
     exporter = exporter_class(query)
-    output = exporter.get_output(delim=delim)
+    try:
+        output = exporter.get_output(delim=delim)
+    except DatabaseError as e:
+        msg = "Error executing query %s: %s" % (query.title, e)
+        logger.warning(msg)
+        return HttpResponse(msg, status_code=500)
     response = HttpResponse(output, content_type=exporter.content_type)
     if download:
         response['Content-Disposition'] = 'attachment; filename="%s"' % (


### PR DESCRIPTION
1. Send an email when someone first requests a query, so they know it worked.
2. If there is an error when running the query asynchronously, alert the user via email (and log it)
3. Show an error if a user tries to download a non-runnable query
4. Improve the UI on the front end to tell the user the result is coming