### PR TITLE
Removes invalid excel characters from worksheet name

### DIFF
--- a/explorer/exporters.py
+++ b/explorer/exporters.py
@@ -99,7 +99,6 @@ class ExcelExporter(BaseExporter):
     name = 'Excel'
     content_type = 'application/vnd.ms-excel'
     file_extension = '.xlsx'
-   
 
     def _get_output(self, res, **kwargs):
         import xlsxwriter

--- a/explorer/exporters.py
+++ b/explorer/exporters.py
@@ -99,6 +99,7 @@ class ExcelExporter(BaseExporter):
     name = 'Excel'
     content_type = 'application/vnd.ms-excel'
     file_extension = '.xlsx'
+   
 
     def _get_output(self, res, **kwargs):
         import xlsxwriter
@@ -106,11 +107,7 @@ class ExcelExporter(BaseExporter):
 
         wb = xlsxwriter.Workbook(output, {'in_memory': True})
 
-        # XLSX writer wont allow sheet names > 31 characters
-        # https://github.com/jmcnamara/XlsxWriter/blob/master/xlsxwriter/test/workbook/test_check_sheetname.py
-        title = self.query.title[:31]
-
-        ws = wb.add_worksheet(name=title)
+        ws = wb.add_worksheet(name=self._format_title())
 
         # Write headers
         row = 0
@@ -138,3 +135,12 @@ class ExcelExporter(BaseExporter):
 
         wb.close()
         return output
+
+    def _format_title(self)
+        # XLSX writer wont allow sheet names > 31 characters or that contain invalid characters
+        # https://github.com/jmcnamara/XlsxWriter/blob/master/xlsxwriter/test/workbook/test_check_sheetname.py
+         title = self.query.title
+         for char in ['\\', '/', '*', '[', ']', ':', '?']:
+            if char in title:
+                title = title.replace(char, ' ')
+         return title[:31]

--- a/explorer/exporters.py
+++ b/explorer/exporters.py
@@ -139,8 +139,8 @@ class ExcelExporter(BaseExporter):
     def _format_title(self):
         # XLSX writer wont allow sheet names > 31 characters or that contain invalid characters
         # https://github.com/jmcnamara/XlsxWriter/blob/master/xlsxwriter/test/workbook/test_check_sheetname.py
-         title = self.query.title
-         for char in ['\\', '/', '*', '[', ']', ':', '?']:
+        title = self.query.title
+        for char in ['\\', '/', '*', '[', ']', ':', '?']:
             if char in title:
                 title = title.replace(char, ' ')
-         return title[:31]
+        return title[:31]

--- a/explorer/exporters.py
+++ b/explorer/exporters.py
@@ -11,6 +11,7 @@ else:
     import unicodecsv as csv
 
 from django.utils.module_loading import import_string
+from django.utils.text import slugify
 from . import app_settings
 from six import StringIO, BytesIO
 
@@ -138,8 +139,5 @@ class ExcelExporter(BaseExporter):
     def _format_title(self):
         # XLSX writer wont allow sheet names > 31 characters or that contain invalid characters
         # https://github.com/jmcnamara/XlsxWriter/blob/master/xlsxwriter/test/workbook/test_check_sheetname.py
-        title = self.query.title
-        for char in ['\\', '/', '*', '[', ']', ':', '?']:
-            if char in title:
-                title = title.replace(char, ' ')
+        title = slugify(self.query.title)
         return title[:31]

--- a/explorer/exporters.py
+++ b/explorer/exporters.py
@@ -136,7 +136,7 @@ class ExcelExporter(BaseExporter):
         wb.close()
         return output
 
-    def _format_title(self)
+    def _format_title(self):
         # XLSX writer wont allow sheet names > 31 characters or that contain invalid characters
         # https://github.com/jmcnamara/XlsxWriter/blob/master/xlsxwriter/test/workbook/test_check_sheetname.py
          title = self.query.title

--- a/explorer/tests/test_exporters.py
+++ b/explorer/tests/test_exporters.py
@@ -64,7 +64,8 @@ class TestExcel(TestCase):
             , by all means submit a pull request!
         """
         res = QueryResult(SimpleQueryFactory(sql='select 1 as "a", 2 as ""',
-                                             title='this title is longer than 32 characters').sql, connections[CONN])
+                                             title='\\/*[]:?this title is longer than 32 characters').sql, connections[CONN])
+
         res.execute_query()
         res.process()
 
@@ -81,7 +82,7 @@ class TestExcel(TestCase):
 
     def test_writing_dict_fields(self):
         res = QueryResult(SimpleQueryFactory(sql='select 1 as "a", 2 as ""',
-                                             title='this title is longer than 32 characters').sql, connections[CONN])
+                                             title='\\/*[]:?this title is longer than 32 characters').sql, connections[CONN])
 
         res.execute_query()
         res.process()


### PR DESCRIPTION
On Excel export, an exception will be raised by `xlsxwriter` if the worksheet name contains invalid characters. https://github.com/jmcnamara/XlsxWriter/blob/81d1ed9f32887f5c6e615b862fcaf3c8bf49c1c2/xlsxwriter/workbook.py#L720

This PR prevents that exception from being raised by replacing an invalid character with a whitespace. We've seen this be raised most commonly by people who have slashes in the query title name.

```
File "/home/ubuntu/env/local/lib/python2.7/site-packages/explorer/exporters.py" in _get_output
  116.         ws = wb.add_worksheet(name=title)

File "/home/ubuntu/env/local/lib/python2.7/site-packages/xlsxwriter/workbook.py" in add_worksheet
  171.         return self._add_sheet(name, is_chartsheet=False)

File "/home/ubuntu/env/local/lib/python2.7/site-packages/xlsxwriter/workbook.py" in _add_sheet
  635.         name = self._check_sheetname(name, is_chartsheet)

File "/home/ubuntu/env/local/lib/python2.7/site-packages/xlsxwriter/workbook.py" in _check_sheetname
  695.                 sheetname)

Exception Type: Exception at /reports/44/download
Exception Value: Invalid Excel character '[]:*?/\' in sheetname 'Investor Metrics - New/Existing'
```