### PR TITLE
added django 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ python:
   - 3.5
   - 3.6
 install:
+  - pip install ${DJANGO}
   - pip install -r requirements.txt
   - pip install -r optional-requirements.txt
-  - pip install ${DJANGO}
 
 script:  python manage.py test
 env:

--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ The following people have contributed to django-sql-explorer:
 - Stanislav Tarazevich
 - Ming Hsien Tseng
 - Jared Proffitt
+- Brad Melin

--- a/explorer/migrations/0001_initial.py
+++ b/explorer/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('description', models.TextField(null=True, blank=True)),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('last_run_date', models.DateTimeField(auto_now=True)),
-                ('created_by_user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+                ('created_by_user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ['title'],
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
                 ('is_playground', models.BooleanField(default=False)),
                 ('run_at', models.DateTimeField(auto_now_add=True)),
                 ('query', models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, blank=True, to='explorer.Query', null=True)),
-                ('run_by_user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+                ('run_by_user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ['-run_at'],

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -1,13 +1,13 @@
-import django
 import logging
 from time import time
 import six
 
 from django.db import models, DatabaseError
-if django.VERSION[1] >= 10:
+try:
     from django.urls import reverse
-else:
+except ImportError:
     from django.core.urlresolvers import reverse
+
 from django.conf import settings
 
 from . import app_settings

--- a/explorer/tests/test_views.py
+++ b/explorer/tests/test_views.py
@@ -1,12 +1,12 @@
-import django
 import json
 import time
 
 from django.test import TestCase
-if django.VERSION[1] >= 10:
+try:
     from django.urls import reverse
-else:
+except ImportError:
     from django.core.urlresolvers import reverse
+
 from django.contrib.auth.models import User
 from explorer.app_settings import EXPLORER_DEFAULT_CONNECTION as CONN
 from django.forms.models import model_to_dict

--- a/explorer/tests/urls.py
+++ b/explorer/tests/urls.py
@@ -6,7 +6,7 @@ from explorer.urls import urlpatterns
 admin.autodiscover()
 
 urlpatterns += [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', include(admin.site.get_urls(), 'admin')),
 ]
 
 urlpatterns += staticfiles_urlpatterns()

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -1,12 +1,12 @@
-import django
 import re
 import six
 from collections import Counter
 
-if django.VERSION[1] >= 10:
+try:
     from django.urls import reverse_lazy
-else:
+except ImportError:
     from django.core.urlresolvers import reverse_lazy
+
 from django.db import DatabaseError
 from django.db.models import Count
 from django.forms.models import model_to_dict


### PR DESCRIPTION
Fixes https://github.com/groveco/django-sql-explorer/issues/309
* Improved import lines to better accommodate new `django.urls` imports.
* Added now-required `on_delete` arguments to migrations so that they match models.
* Reordered travis install order to ensure that correct Django version is always installed.