### PR TITLE
Cast UUID to string, because XlsxWriter can't write it

### DIFF
--- a/explorer/exporters.py
+++ b/explorer/exporters.py
@@ -1,6 +1,7 @@
 from django.db import DatabaseError
 from django.core.serializers.json import DjangoJSONEncoder
 import json
+import uuid
 import string
 import sys
 from datetime import datetime
@@ -122,8 +123,10 @@ class ExcelExporter(BaseExporter):
         col = 0
         for data_row in res.data:
             for data in data_row:
-                # xlsxwriter can't handle timezone-aware datetimes, so we help out here and just cast it to a string
-                if isinstance(data, datetime):
+                # xlsxwriter can't handle timezone-aware datetimes or
+                # UUIDs, so we help out here and just cast it to a
+                # string
+                if isinstance(data, datetime) or isinstance(data, uuid.UUID):
                     data = str(data)
                 # JSON and Array fields
                 if isinstance(data, dict) or isinstance(data, list):


### PR DESCRIPTION
Apparently this is a deliberate feature of XlsxWriter, because it tries to convert Python types to native Excel types, and there is no native UUID type in Excel. The suggestion is that if you want something mapped to string, you should do it before writing it to XlsxWriter.