### PR TITLE
Add optional-requirements to start.sh

### DIFF
--- a/test_project/start.sh
+++ b/test_project/start.sh
@@ -1,4 +1,5 @@
 pip install -r requirements.txt
+pip install -r optional-requirements.txt
 python manage.py migrate
 python manage.py shell <<ORM
 from django.contrib.auth.models import User


### PR DESCRIPTION
Now Django-celery is required to run start.sh.