### PR TITLE
Fixes

### DIFF
--- a/explorer/forms.py
+++ b/explorer/forms.py
@@ -56,7 +56,7 @@ class QueryForm(ModelForm):
 
     @property
     def connections(self):
-        return zip(app_settings.EXPLORER_CONNECTIONS.values(), app_settings.EXPLORER_CONNECTIONS.keys())
+        return [(v, k) for k, v in app_settings.EXPLORER_CONNECTIONS.items()]
 
     class Meta:
         model = Query

--- a/explorer/tasks.py
+++ b/explorer/tasks.py
@@ -77,7 +77,7 @@ def truncate_querylogs(days):
 
 @task
 def build_schema_cache_async(connection_alias):
-    from schema import build_schema_info, connection_schema_cache_key
+    from .schema import build_schema_info, connection_schema_cache_key
     ret = build_schema_info(connection_alias)
     cache.set(connection_schema_cache_key(connection_alias), ret)
     return ret

--- a/explorer/tests/test_schema.py
+++ b/explorer/tests/test_schema.py
@@ -3,16 +3,6 @@ from django.core.cache import cache
 from explorer.app_settings import EXPLORER_DEFAULT_CONNECTION as CONN
 from explorer import schema
 from mock import patch
-import sys
-
-
-# Totally unclear why this is necessary but py2 and py3
-# want these patches slightly differently.
-PY3 = sys.version_info[0] == 3
-if PY3:
-    patch_location = 'schema.'
-else:
-    patch_location = 'explorer.schema.'
 
 
 class TestSchemaInfo(TestCase):
@@ -20,17 +10,18 @@ class TestSchemaInfo(TestCase):
     def setUp(self):
         cache.clear()
 
-    @patch(patch_location + '_get_includes')
-    @patch(patch_location + '_get_excludes')
+    @patch('explorer.schema._get_includes')
+    @patch('explorer.schema._get_excludes')
     def test_schema_info_returns_valid_data(self, mocked_excludes, mocked_includes):
         mocked_includes.return_value = None
         mocked_excludes.return_value = []
         res = schema.schema_info(CONN)
+        assert mocked_includes.called  # sanity check: ensure patch worked
         tables = [x[0] for x in res]
         self.assertIn('explorer_query', tables)
 
-    @patch(patch_location + '_get_includes')
-    @patch(patch_location + '_get_excludes')
+    @patch('explorer.schema._get_includes')
+    @patch('explorer.schema._get_excludes')
     def test_table_exclusion_list(self, mocked_excludes, mocked_includes):
         mocked_includes.return_value = None
         mocked_excludes.return_value = ('explorer_',)
@@ -38,8 +29,8 @@ class TestSchemaInfo(TestCase):
         tables = [x[0] for x in res]
         self.assertNotIn('explorer_query', tables)
 
-    @patch(patch_location + '_get_includes')
-    @patch(patch_location + '_get_excludes')
+    @patch('explorer.schema._get_includes')
+    @patch('explorer.schema._get_excludes')
     def test_app_inclusion_list(self, mocked_excludes, mocked_includes):
         mocked_includes.return_value = ('auth_',)
         mocked_excludes.return_value = []
@@ -48,8 +39,8 @@ class TestSchemaInfo(TestCase):
         self.assertNotIn('explorer_query', tables)
         self.assertIn('auth_user', tables)
 
-    @patch(patch_location + '_get_includes')
-    @patch(patch_location + '_get_excludes')
+    @patch('explorer.schema._get_includes')
+    @patch('explorer.schema._get_excludes')
     def test_app_inclusion_list_excluded(self, mocked_excludes, mocked_includes):
         # Inclusion list "wins"
         mocked_includes.return_value = ('explorer_',)

--- a/explorer/tests/test_tasks.py
+++ b/explorer/tests/test_tasks.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
-from explorer.tasks import execute_query, snapshot_queries, truncate_querylogs
+from explorer.app_settings import EXPLORER_DEFAULT_CONNECTION as CONN
+from explorer.tasks import execute_query, snapshot_queries, truncate_querylogs, build_schema_cache_async
 from explorer.tests.factories import SimpleQueryFactory
 from django.core import mail
 from mock import Mock, patch
@@ -59,3 +60,10 @@ class TestTasks(TestCase):
         QueryLog.objects.filter(sql='bar').update(run_at=datetime.now() - timedelta(days=29))
         truncate_querylogs(30)
         self.assertEqual(QueryLog.objects.count(), 1)
+
+    @patch('explorer.schema.build_schema_info')
+    def test_build_schema_cache_async(self, mocked_build):
+        mocked_build.return_value = ['list_of_tuples']
+        schema = build_schema_cache_async(CONN)
+        assert mocked_build.called
+        self.assertEqual(schema, ['list_of_tuples'])


### PR DESCRIPTION
The connections select list wasn't populating for me, which broke the url for the schema iframe.  The zip builtin returns an iterator that must have been getting evaluated more than once.  Changing to a list fixed the problem.

Fixing the import in build_schema_cache_async caused a couple of tests to fail because the patches in those tests weren't actually working.  This includes a new test that fails unless the import is fixed, a sanity check in the broken tests to ensure that the patched version of _get_includes is called, and fixes for the patches in test_schema.py