### PR TITLE
Fix  auth.views.login (to support Django2.1)

### DIFF
--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -2,7 +2,10 @@ import functools
 import re
 
 from django.contrib.auth.forms import AuthenticationForm
-from django.contrib.auth.views import login
+try:
+    from django.contrib.auth import login
+except ImportError:
+    from django.contrib.auth.views import login
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from six import text_type
 import sqlparse


### PR DESCRIPTION
Update code to support Django2.1 

django.contrib.auth.views.login was removed from Django 2.1
Use django.conrib.auth.login instead.