### PR TITLE
URL-friendly parameter encoding

### DIFF
--- a/explorer/static/explorer/explorer.js
+++ b/explorer/static/explorer/explorer.js
@@ -51,9 +51,9 @@ ExplorerEditor.prototype.getParams = function() {
 ExplorerEditor.prototype.serializeParams = function(params) {
     var args = [];
     for(var key in params) {
-        args.push(key + '%3A' + params[key]);
+        args.push(key + ':' + params[key]);
     }
-    return args.join('%7C');
+    return encodeURIComponent(args.join('|'))
 };
 
 ExplorerEditor.prototype.doCodeMirrorSubmit = function() {


### PR DESCRIPTION
Sometimes it is necessary to pass special characters like ' & ' in parameters, e.g.:
SELECT * FROM table WHERE field = '$$Param1:p1&p2$$' 
serializeParams doesn't encode the '&' character properly and it breaks query string parameter pairs.