### PR TITLE
Use configured admin's default site login_template

### DIFF
--- a/explorer/views.py
+++ b/explorer/views.py
@@ -20,6 +20,7 @@ from django.views.generic.base import View
 from django.views.generic.edit import CreateView, DeleteView
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.core.exceptions import ImproperlyConfigured
+from django.contrib import admin
 from django.contrib.auth import REDIRECT_FIELD_NAME
 
 if django.VERSION >= (1, 11):
@@ -95,7 +96,7 @@ class PermissionRequiredMixin(object):
 
 if django.VERSION > (1, 11):
     class SafeLoginView(LoginView):
-        template_name = 'admin/login.html'
+        template_name = admin.site.login_template
 
 
 def _export(request, query, download=True):


### PR DESCRIPTION
If the developer modifies their default admin site `login_template`, this will allow `explorer` to respect the specified `login_template`. This has the benefit of also making no change if the developer does not change the default admin site.

Override default admin: https://docs.djangoproject.com/en/dev/ref/contrib/admin/#overriding-the-default-admin-site
Changing the admin login_template: https://docs.djangoproject.com/en/dev/ref/contrib/admin/#django.contrib.admin.AdminSite.login_template

According do the docs, the `login_template` attribute dates back to 1.7 at least.