### PR TITLE
Fix unicode issue when generating migration with py2 or py3

### DIFF
--- a/explorer/migrations/0008_auto_20190308_1642.py
+++ b/explorer/migrations/0008_auto_20190308_1642.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('explorer', '0007_querylog_connection'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='query',
+            name='connection',
+            field=models.CharField(blank=True, help_text='Name of DB connection (as specified in settings) to use for this query. Will use EXPLORER_DEFAULT_CONNECTION if left blank', max_length=128, null=True),
+        ),
+    ]

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 from time import time
 import six
@@ -26,7 +28,7 @@ MSG_FAILED_BLACKLIST = "Query failed the SQL blacklist: %s"
 
 logger = logging.getLogger(__name__)
 
-
+@six.python_2_unicode_compatible
 class Query(models.Model):
     title = models.CharField(max_length=255)
     sql = models.TextField()
@@ -47,7 +49,7 @@ class Query(models.Model):
         ordering = ['title']
         verbose_name_plural = 'Queries'
 
-    def __unicode__(self):
+    def __str__(self):
         return six.text_type(self.title)
 
     def get_run_count(self):
@@ -228,6 +230,7 @@ class QueryResult(object):
         return cursor, ((time() - start_time) * 1000)
 
 
+@six.python_2_unicode_compatible
 class ColumnHeader(object):
 
     def __init__(self, title):
@@ -237,13 +240,11 @@ class ColumnHeader(object):
     def add_summary(self, column):
         self.summary = ColumnSummary(self, column)
 
-    def __unicode__(self):
-        return self.title
-
     def __str__(self):
         return self.title
 
 
+@six.python_2_unicode_compatible
 class ColumnStat(object):
 
     def __init__(self, label, statfn, precision=2, handles_null=False):
@@ -255,10 +256,11 @@ class ColumnStat(object):
     def __call__(self, coldata):
         self.value = round(float(self.statfn(coldata)), self.precision) if coldata else 0
 
-    def __unicode__(self):
+    def __str__(self):
         return self.label
 
 
+@six.python_2_unicode_compatible
 class ColumnSummary(object):
 
     def __init__(self, header, col):


### PR DESCRIPTION
Running makemigrations on Python 3 will generate a new migration because of Query.connection.help_text which is not unicode on Python 2 which lead to a migration file with byte see explorer/migrations/0006_query_connection.py
```
migrations.AddField(
            model_name='query',
            name='connection',
            field=models.CharField(help_text=b'Name of DB connection (as specified in settings) to use for this query. Will use EXPLORER_DEFAULT_CONNECTION if left blank', max_length=128, null=True, blank=True),
        ),
```
Adding `from __future__ import unicode_literals` will solve this problem but I've to add the right migration any way so that Django will not try generate a new one using Python3.

I have also added minor fixes to use `@six.python_2_unicode_compatible`

I hope this will be merged and released as soon as possible. 