### PR TITLE
Run queries as atomic requests

### DIFF
--- a/explorer/models.py
+++ b/explorer/models.py
@@ -4,7 +4,7 @@ import logging
 from time import time
 import six
 
-from django.db import models, DatabaseError
+from django.db import models, DatabaseError, transaction
 try:
     from django.urls import reverse
 except ImportError:
@@ -222,7 +222,8 @@ class QueryResult(object):
         start_time = time()
 
         try:
-            cursor.execute(self.sql)
+            with transaction.atomic(self.connection.alias):
+                cursor.execute(self.sql)
         except DatabaseError as e:
             cursor.close()
             raise e


### PR DESCRIPTION
Without this, a query error (eg. a typo in a table name) causes a 500-level error if the default database connection has ATOMIC_REQUESTS set to True. This is because once the query fails, no other database query succeeds (eg. trying to access the database to render the error page).