### PR TITLE
Add XlsxWriter module (required to export to Excel) to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django>=1.11.0
 six==1.12.0
 sqlparse==0.3.0
 unicodecsv==0.14.1
+XlsxWriter==1.2.8


### PR DESCRIPTION
Steps to reproduce issue: Try export to Excel any query results.
Actual results: You get an error: ModuleNotFoundError: No module named 'xlsxwriter'.
The solution is to add this module to requirements.txt.