### PR TITLE
Enhancement: Collapsable SQL panel

### DIFF
--- a/explorer/static/explorer/css/explorer.css
+++ b/explorer/static/explorer/css/explorer.css
@@ -169,3 +169,7 @@ a#fullscreen {
 .sql {
     width: 33%;
 }
+
+.hide-sql {
+    display: none;
+}

--- a/explorer/static/explorer/css/explorer.css
+++ b/explorer/static/explorer/css/explorer.css
@@ -170,6 +170,7 @@ a#fullscreen {
     width: 33%;
 }
 
-.hide-sql {
-    display: none;
+#sql_toggle {
+    padding-left: 1rem;
+    color: #18bc9c;
 }

--- a/explorer/templates/explorer/query.html
+++ b/explorer/templates/explorer/query.html
@@ -67,7 +67,7 @@
                 {% if form.sql.errors %}{% for error in form.sql.errors %}
                     <div class="alert alert-danger">{{ error|escape }}</div>
                 {% endfor %}{% endif %}
-                <div class="panel panel-default sql-panel {% if query %}toggle-sql{% endif %}">
+                <div class="panel panel-default sql-panel">
                     <div class="panel-heading">
                       <div class="row">
                         <div class="col-md-6">
@@ -75,7 +75,8 @@
                         </div>
                         <div class="col-md-6 text-right">
                           {% if query %}
-                            <small><a href="#" title="Open in playground" id="playground_button"><i class="glyphicon glyphicon-new-window"></i></a></small>
+                              <small><a href="#" title="Open in playground" id="playground_button"><i class="glyphicon glyphicon-new-window"></i></a></small>
+                              <small><i id="sql_toggle" class="glyphicon glyphicon-resize-full"></i></small>
                           {% endif %}
                         </div>
                       </div>
@@ -102,12 +103,9 @@
                                 <li><input type="submit" value="{% trans 'Save Only' %}" class="btn btn-link" id="save_only"/></li>
                               </ul>
                             </div>
-                            <button type="button" class="btn btn-default {% if query %}toggle-sql{% endif %}" id="format_button">{% trans "Format" %}</button>
-                            <button type="button" class="btn btn-default {% if query %}toggle-sql{% endif %}" id="show_schema_button">{% trans "Show Schema" %}</button>
+                            <button type="button" class="btn btn-default" id="format_button">{% trans "Format" %}</button>
+                            <button type="button" class="btn btn-default" id="show_schema_button">{% trans "Show Schema" %}</button>
                             <button type="button" class="btn btn-default" id="hide_schema_button" style="display: none;">{% trans "Hide Schema" %}</button>
-                            {% if query %}
-                                <button type="button" class="btn btn-info js-sql-toggle" id="sql_button">{% trans "Toggle SQL" %}</button>
-                            {% endif %}
                         {% else %}
                             <input type="submit" value="{% trans 'Refresh' %}" class="btn btn-default" id="refresh_button" />
                             <div class="btn-group">
@@ -153,10 +151,17 @@
         $(function() {
             var e = new ExplorerEditor(queryId);
 
-            $('.js-sql-toggle').on('click', function () {
-                $('.toggle-sql').slideToggle('slow');
+            $('#sql_toggle').on('click', function () {
+                $('.panel-content').slideToggle('slow');
+
+                if ($(this).hasClass('glyphicon-resize-full')) {
+                    $(this).addClass('glyphicon-resize-small').removeClass('glyphicon-resize-full');
+                } else {
+                    $(this).addClass('glyphicon-resize-full').removeClass('glyphicon-resize-small');
+                }
+
             })
-            $('.toggle-sql').hide();
+            $('.panel-content').hide();
         });
     </script>
 {% endblock %}

--- a/explorer/templates/explorer/query.html
+++ b/explorer/templates/explorer/query.html
@@ -67,7 +67,7 @@
                 {% if form.sql.errors %}{% for error in form.sql.errors %}
                     <div class="alert alert-danger">{{ error|escape }}</div>
                 {% endfor %}{% endif %}
-                <div class="panel panel-default sql-panel">
+                <div class="panel panel-default sql-panel {% if query %}toggle-sql{% endif %}">
                     <div class="panel-heading">
                       <div class="row">
                         <div class="col-md-6">
@@ -91,8 +91,8 @@
                     <div class="text-center">
                         {% if can_change %}
                             <div class="btn-group">
-                              <input type="submit" value="{% trans 'Save & Run' %}" class="btn btn-default" id="save_button" />
-                              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                              <input type="submit" value="{% trans 'Save & Run' %}" class="btn btn-primary" id="save_button" />
+                              <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <span class="caret"></span>
                                 <span class="sr-only">{% trans "Toggle Dropdown" %}</span>
                               </button>
@@ -102,9 +102,12 @@
                                 <li><input type="submit" value="{% trans 'Save Only' %}" class="btn btn-link" id="save_only"/></li>
                               </ul>
                             </div>
-                            <button type="button" class="btn btn-default" id="show_schema_button">{% trans "Show Schema" %}</button>
+                            <button type="button" class="btn btn-default {% if query %}toggle-sql{% endif %}" id="format_button">{% trans "Format" %}</button>
+                            <button type="button" class="btn btn-default {% if query %}toggle-sql{% endif %}" id="show_schema_button">{% trans "Show Schema" %}</button>
                             <button type="button" class="btn btn-default" id="hide_schema_button" style="display: none;">{% trans "Hide Schema" %}</button>
-                            <button type="button" class="btn btn-default" id="format_button">{% trans "Format" %}</button>
+                            {% if query %}
+                                <button type="button" class="btn btn-info js-sql-toggle" id="sql_button">{% trans "Toggle SQL" %}</button>
+                            {% endif %}
                         {% else %}
                             <input type="submit" value="{% trans 'Refresh' %}" class="btn btn-default" id="refresh_button" />
                             <div class="btn-group">
@@ -149,6 +152,11 @@
     <script>
         $(function() {
             var e = new ExplorerEditor(queryId);
+
+            $('.js-sql-toggle').on('click', function () {
+                $('.toggle-sql').slideToggle('slow');
+            })
+            $('.toggle-sql').hide();
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
# Description

When opening a saved query, the main point of interest is generally the data, not the SQL itself.

This adds a toggle glyph to show/hide the SQL content panel.

<img width="1163" alt="Screenshot 2020-12-08 at 16 52 17" src="https://user-images.githubusercontent.com/1461191/101517852-2173df00-3979-11eb-9349-c049d4bb13ab.png">


## References

Fix #244
