### PR TITLE
Add link to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,8 @@ The original idea came from Stack Exchange's `Data Explorer
 credit to similar projects like `Redash <http://redash.io/>`_ and
 `Blazer <https://github.com/ankane/blazer>`_.
 
+You can read the full documentation `here <https://django-sql-explorer.readthedocs.io/en/latest/>`_
+
 Sql Explorer is MIT licensed, and pull requests are welcome.
 
 **A view of a query**


### PR DESCRIPTION
I struggeled to find the documentation, eventually finding a link in this PR: https://github.com/groveco/django-sql-explorer/pull/410#issuecomment-710662949

I think it would be helpful to put a link in the readme.