### PR TITLE
allow override of the no permissions view

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -20,6 +20,7 @@ EXPLORER_RECENT_QUERY_COUNT             The number of recent queries to show at 
 EXPLORER_GET_USER_QUERY_VIEWS           A dict granting view permissions on specific queries of the form {userId:[queryId, ...], ...}                   {}
 EXPLORER_TOKEN_AUTH_ENABLED             Bool indicating whether token-authenticated requests should be enabled. See "Power Tips", above.                False
 EXPLORER_TOKEN                          Access token for query results.                                                                                 "CHANGEME"
+EXPLORER_NO_PERMISSION_VIEW             Path to a view to use when the user does not have permission to view a page                                     'explorer.views.auth.safe_login_view_wrapper'  # By default, a basic login view is provided.
 EXPLORER_TASKS_ENABLED                  Turn on if you want to use the snapshot_queries celery task, or email report functionality in tasks.py          False
 EXPLORER_S3_ACCESS_KEY                  S3 Access Key for snapshot upload                                                                               None
 EXPLORER_S3_SECRET_KEY                  S3 Secret Key for snapshot upload                                                                               None

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from pydoc import locate
 
 # The 'correct' configuration for Explorer looks like:
 
@@ -107,6 +108,13 @@ EXPLORER_GET_USER_QUERY_VIEWS = lambda: getattr(  # noqa
 )
 EXPLORER_TOKEN_AUTH_ENABLED = lambda: getattr(  # noqa
     settings, 'EXPLORER_TOKEN_AUTH_ENABLED', False
+)
+EXPLORER_NO_PERMISSION_VIEW = lambda: locate(# noqa
+    getattr(
+        settings,
+        'EXPLORER_NO_PERMISSION_VIEW',
+        'explorer.views.auth.safe_login_view_wrapper',
+    ),
 )
 
 # Async task related. Note that the EMAIL_HOST settings must be set up for

--- a/explorer/views/auth.py
+++ b/explorer/views/auth.py
@@ -3,7 +3,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import LoginView
 from django.core.exceptions import ImproperlyConfigured
 
-from explorer import permissions
+from explorer import permissions, app_settings
 
 
 class PermissionRequiredMixin:
@@ -12,12 +12,7 @@ class PermissionRequiredMixin:
 
     @staticmethod
     def handle_no_permission(request):
-        return SafeLoginView.as_view(
-            extra_context={
-                'title': 'Log in',
-                REDIRECT_FIELD_NAME: request.get_full_path()
-            }
-        )(request)
+        return app_settings.EXPLORER_NO_PERMISSION_VIEW()(request)
 
     def get_permission_required(self):
         if self.permission_required is None:
@@ -46,3 +41,12 @@ class PermissionRequiredMixin:
 
 class SafeLoginView(LoginView):
     template_name = 'admin/login.html'
+
+
+def safe_login_view_wrapper(request):
+    return SafeLoginView.as_view(
+        extra_context={
+            'title': 'Log in',
+            REDIRECT_FIELD_NAME: request.get_full_path()
+        }
+    )(request)


### PR DESCRIPTION
Implements #440 

This PR adds an `EXPLORER_NO_PERMISSION_VIEW` configuration option. Library consumers can set this to render custom view when users does not have permission to view a page within explorer. If the option is not set, the existing `SafeLoginView` is used. 

The library consumer can simply return a redirect from that view, or, they can handle logged in and anonymous users differently.

The option is a view path (e.g. `consumerapp.mymodule.myfiewfunc`), and the custom view has to be function based. This required wrapping the class based `SafeLoginView`. Let me know if you'd like this done differently, we're happy to implement it however you think would best fit with the app.