### PR TITLE
Translates expression for duration

### DIFF
--- a/explorer/templates/explorer/preview_pane.html
+++ b/explorer/templates/explorer/preview_pane.html
@@ -16,7 +16,7 @@
                               <div class="row">
                                 <div class="col-md-6">
                                   {% if data %}<a title="Show row numbers" id="counter-toggle" href="#">#</a>&nbsp;{% endif %}
-                                  <span class="panel-title">{% blocktrans %}Execution time: {{ duration|floatformat:2 }} ms{% endblocktrans %}</span>
+                                  <span class="panel-title">{% blocktrans with duration|floatformat:2 as duration %}Execution time: {{ duration }} ms{% endblocktrans %}</span>
                                 </div>
                                 <div class="col-md-6 text-right">
                                   <span class="row-control">

--- a/explorer/templates/explorer/preview_pane.html
+++ b/explorer/templates/explorer/preview_pane.html
@@ -16,7 +16,7 @@
                               <div class="row">
                                 <div class="col-md-6">
                                   {% if data %}<a title="Show row numbers" id="counter-toggle" href="#">#</a>&nbsp;{% endif %}
-                                  <span class="panel-title">{% blocktrans with duration|floatformat:2 as duration %}Execution time: {{ duration }} ms{% endblocktrans %}</span>
+                                  <span class="panel-title">{% blocktrans with duration=duration|floatformat:2 %}Execution time: {{ duration }} ms{% endblocktrans %}</span>
                                 </div>
                                 <div class="col-md-6 text-right">
                                   <span class="row-control">


### PR DESCRIPTION
I am running django 3.2 and noticed that the execution time is blank. e.g.

![image](https://user-images.githubusercontent.com/706148/125558591-1f60ee5f-eeac-490d-8a06-3c37f0dddc49.png)

https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#blocktrans-template-tag
The django docs are clear that expressions should be bound to a local variable before being used inside the translation tag.

I've chosen to use the ~older format for the expression binding since this should cover a wider range of django installs~ newer format because it is also available for a wide range of django installs.

![image](https://user-images.githubusercontent.com/706148/125558882-7a403ec5-a115-4611-bbc3-97376888bc5e.png)
