### PR TITLE
Add missing comma

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -19,7 +19,7 @@ Disallowed words in SQL queries to prevent destructive actions.
        'DROP',
        'GRANT',
        'INSERT INTO',
-       'OWNER TO'
+       'OWNER TO',
        'RENAME ',
        'REPLACE',
        'SCHEMA',


### PR DESCRIPTION
Minor fix to avoid confusion when someone copies permissions from the documentation (may cause permissions to behave unexpectedly)