### PR TITLE
Add SET to blacklisted keywords

### DIFF
--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -28,7 +28,8 @@ EXPLORER_SQL_BLACKLIST = getattr(
         'DELETE',
         'CREATE TABLE',
         'GRANT',
-        'OWNER TO'
+        'OWNER TO',
+        'SET'
     )
 )
 


### PR DESCRIPTION
Someone can pass this query to change the password of a database user 

`SET PASSWORD FOR 'user-name-here'= PASSWORD('new-password');`

this is the syntax for MySQL database server version 5.7.5 or older.


That's why I suggest adding SET to the default black list