### PR TITLE
Fix for #483

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 `unreleased`_ changes
 ---------------------
 
+* #484: Avoid creating migration when using `BigAutoField` as `DEFAULT_AUTO_FIELD`
+
 `2.4.1`_ (2022-03-10)
 ---------------------
 * `#471`_: Fix extra white space in description and SQL fields.

--- a/explorer/apps.py
+++ b/explorer/apps.py
@@ -8,6 +8,7 @@ class ExplorerAppConfig(AppConfig):
 
     name = 'explorer'
     verbose_name = _('SQL Explorer')
+    default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
         from explorer.schema import build_async_schemas


### PR DESCRIPTION
I actually had to create the PR because I needed to use that instead of the pypi release on my requirements to avoid the bad migration. 