### PR TITLE
Sql explorer save query params

### DIFF
--- a/explorer/migrations/0009_auto_20220830_1545.py
+++ b/explorer/migrations/0009_auto_20220830_1545.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('explorer', '0008_auto_20190308_1642'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='QueryParam',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('key', models.CharField(blank=True, max_length=128, null=True)),
+                ('value', models.CharField(blank=True, max_length=255, null=True)),
+                ('query', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='query_params', to='explorer.Query')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='queryparam',
+            unique_together=set([('query', 'key')]),
+        ),
+    ]

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -128,6 +128,21 @@ class Query(models.Model):
             return [SnapShot(k.generate_url(expires_in=0, query_auth=False),
                              k.last_modified) for k in keys_s]
 
+    def create_query_params(self, data):
+        '''
+        Method to create the QueryParam objects and associate them to a Query obj
+        Args:
+            - `data`: dict
+        '''
+        # First remove all associated QueryParam objs before creating new ones
+        self.query_params.all().delete()
+        query_params_to_create = [
+            QueryParam(query=self, key=k, value=v)
+            for k, v in data.items()
+        ]
+        # Now bulk create new ones
+        QueryParam.objects.bulk_create(query_params_to_create)
+
 
 class SnapShot(object):
 

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -41,7 +41,6 @@ class Query(models.Model):
                                   help_text="Name of DB connection (as specified in settings) to use for this query. Will use EXPLORER_DEFAULT_CONNECTION if left blank")
 
     def __init__(self, *args, **kwargs):
-        self.params = kwargs.get('params')
         kwargs.pop('params', None)
         super(Query, self).__init__(*args, **kwargs)
 
@@ -51,6 +50,10 @@ class Query(models.Model):
 
     def __str__(self):
         return six.text_type(self.title)
+
+    @property
+    def params(self):
+        return {k: v for k, v in self.query_params.values_list('key', 'value')}
 
     def get_run_count(self):
         return self.querylog_set.count()
@@ -148,6 +151,21 @@ class QueryLog(models.Model):
 
     class Meta:
         ordering = ['-run_at']
+
+
+class QueryParam(models.Model):
+    key = models.CharField(blank=True, null=True, max_length=128)
+    value = models.CharField(blank=True, null=True, max_length=255)
+    query = models.ForeignKey(
+        Query,
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name='query_params'
+    )
+
+    class Meta:
+        unique_together = ('query', 'key')
 
 
 class QueryResult(object):

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -176,21 +176,3 @@ def s3_upload(key, data):
     k.set_acl('public-read')
     k.set_metadata('Content-Type', 'text/csv')
     return k.generate_url(expires_in=0, query_auth=False)
-
-
-def create_query_params(query, data):
-    '''
-    Method to create the QueryParam objects and associate them to a Query obj
-    Args:
-        - `query`: Query object
-        - `data`: dict
-    '''
-    from explorer.models import QueryParam
-    # First remove all associated QueryParam objs before creating new ones
-    query.query_params.all().delete()
-    query_params_to_create = [
-        QueryParam(query=query, key=k, value=v)
-        for k, v in data.items()
-    ]
-    # Now bulk create new ones
-    QueryParam.objects.bulk_create(query_params_to_create)

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -177,3 +177,20 @@ def s3_upload(key, data):
     k.set_metadata('Content-Type', 'text/csv')
     return k.generate_url(expires_in=0, query_auth=False)
 
+
+def create_query_params(query, data):
+    '''
+    Method to create the QueryParam objects and associate them to a Query obj
+    Args:
+        - `query`: Query object
+        - `data`: dict
+    '''
+    from explorer.models import QueryParam
+    # First remove all associated QueryParam objs before creating new ones
+    query.query_params.all().delete()
+    query_params_to_create = [
+        QueryParam(query=query, key=k, value=v)
+        for k, v in data.items()
+    ]
+    # Now bulk create new ones
+    QueryParam.objects.bulk_create(query_params_to_create)

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -40,7 +40,8 @@ from explorer.utils import (
     fmt_sql,
     allowed_query_pks,
     url_get_show,
-    url_get_fullscreen
+    url_get_fullscreen,
+    create_query_params
 )
 
 from explorer.schema import schema_info
@@ -101,7 +102,9 @@ if django.VERSION > (1, 11):
 def _export(request, query, download=True):
     format = request.GET.get('format', 'csv')
     exporter_class = get_exporter_class(format)
-    query.params = url_get_params(request)
+    query_params = url_get_params(request)
+    if query_params:
+        create_query_params(query, query_params)
     delim = request.GET.get('delim')
     exporter = exporter_class(query)
     try:
@@ -377,7 +380,9 @@ class QueryView(PermissionRequiredMixin, ExplorerContextMixin, View):
     @staticmethod
     def get_instance_and_form(request, query_id):
         query = get_object_or_404(Query, pk=query_id)
-        query.params = url_get_params(request)
+        query_params = url_get_params(request)
+        if query_params:
+            create_query_params(query, query_params)
         form = QueryForm(request.POST if len(request.POST) else None, instance=query)
         return query, form
 

--- a/explorer/views.py
+++ b/explorer/views.py
@@ -40,8 +40,7 @@ from explorer.utils import (
     fmt_sql,
     allowed_query_pks,
     url_get_show,
-    url_get_fullscreen,
-    create_query_params
+    url_get_fullscreen
 )
 
 from explorer.schema import schema_info
@@ -104,7 +103,7 @@ def _export(request, query, download=True):
     exporter_class = get_exporter_class(format)
     query_params = url_get_params(request)
     if query_params:
-        create_query_params(query, query_params)
+        query.create_query_params(query_params)
     delim = request.GET.get('delim')
     exporter = exporter_class(query)
     try:
@@ -382,7 +381,7 @@ class QueryView(PermissionRequiredMixin, ExplorerContextMixin, View):
         query = get_object_or_404(Query, pk=query_id)
         query_params = url_get_params(request)
         if query_params:
-            create_query_params(query, query_params)
+            query.create_query_params(query_params)
         form = QueryForm(request.POST if len(request.POST) else None, instance=query)
         return query, form
 


### PR DESCRIPTION
### Description

This provides the functionality to save query params so that the queries execute with them each time one comes to the Query Detail page.

Resolves: #482

### Deployment Procedures

* [ ] Migration (Please specify app(s) below)
    - `./manage.py migrate explorer`

### Tests

Execute Manual UI Tests like the following:
1. Create a new query with a query param and save, note the same functionality exists as previously where the query does not execute due to no value for the new param:
<img width="1584" alt="Screen Shot 2022-09-01 at 10 57 38 AM" src="https://user-images.githubusercontent.com/13126248/187947481-0050860a-362a-4fb2-8516-c7b6ef526dd0.png">

2. Input a value for the parameter and save:
<img width="1584" alt="Screen Shot 2022-09-01 at 10 57 52 AM" src="https://user-images.githubusercontent.com/13126248/187947853-40940d74-db41-4168-b698-f71e687481fd.png">

3. Now add a new parameter and save:
<img width="1580" alt="Screen Shot 2022-09-01 at 10 58 39 AM" src="https://user-images.githubusercontent.com/13126248/187948003-54ee3cdd-611e-4943-be93-1588341cd488.png">

4. Now save a new value to the second parameter:
<img width="1584" alt="Screen Shot 2022-09-01 at 10 58 53 AM" src="https://user-images.githubusercontent.com/13126248/187948136-3aff179f-3633-4248-84de-3665116d0715.png">

5. Now navigate back to the Query List page and click on the test query:
<img width="1584" alt="Screen Shot 2022-09-01 at 10 59 08 AM" src="https://user-images.githubusercontent.com/13126248/187948194-0b0fec13-bd56-423d-b056-84479f695b65.png">

6. Validate that the new `QueryParams` persist and the query executed:

<img width="1586" alt="Screen Shot 2022-09-01 at 10 59 41 AM" src="https://user-images.githubusercontent.com/13126248/187948490-8d1a7fdb-7504-413a-8658-1b6fed1dccd9.png">


Also, you will want to verify that the csv and JSON exports still work correctly like:

<img width="1456" alt="Screen Shot 2022-09-01 at 11 08 54 AM" src="https://user-images.githubusercontent.com/13126248/187949043-eb092e4a-77e2-499f-96f4-1bcd815ed653.png">

<img width="1439" alt="Screen Shot 2022-09-01 at 11 09 13 AM" src="https://user-images.githubusercontent.com/13126248/187949067-164e2753-b103-43cc-9db1-d14d80591f24.png">
