### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -84,7 +84,7 @@ Schema Helper
   schema. This can sometimes be slow, as it issues a separate
   query for each table it introspects. Therefore, once generated,
   Explorer caches the schema information. There is also the option
-  to generate the schema information asyncronously, via Celery. To
+  to generate the schema information asynchronously, via Celery. To
   enable this, make sure Celery is installed and configured, and
   set ``EXPLORER_ENABLE_TASKS`` and ``EXPLORER_ASYNC_SCHEMA`` to
   ``True``.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -63,7 +63,7 @@ use. The keys of the connections dictionary are friendly names to show
 Explorer users, and the values are the actual database aliases used in
 ``settings.DATABASES``. It is highly recommended to setup read-only roles
 in your database, add them in your project's ``DATABASES`` setting and 
-use these read-only cconnections in the ``EXPLORER_CONNECTIONS``.
+use these read-only connections in the ``EXPLORER_CONNECTIONS``.
 
 If you want to quickly use django-sql-explorer with the existing default
 connection **and know what you are doing** (or you are on development), you

--- a/explorer/charts.py
+++ b/explorer/charts.py
@@ -49,7 +49,7 @@ def get_line_chart(result: QueryResult) -> Optional[str]:
 
     A line chart is rendered if
     * there is at least on row of in the result table
-    * there is at least one numeric column (the first colum (with index 0) does not count)
+    * there is at least one numeric column (the first column (with index 0) does not count)
 
     The first column is used as x-axis labels.
     All other numeric columns represent a line on the chart.


### PR DESCRIPTION
There are small typos in:
- docs/features.rst
- docs/install.rst
- explorer/charts.py

Fixes:
- Should read `connections` rather than `cconnections`.
- Should read `column` rather than `colum`.
- Should read `asynchronously` rather than `asyncronously`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md