### PR TITLE
Fixes Security hole in blacklist for MySQL #490

### DIFF
--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -22,7 +22,7 @@ EXPLORER_SQL_BLACKLIST = getattr(
         'RENAME ',
         'DROP',
         'TRUNCATE',
-        'INSERT INTO',
+        'INSERT',
         'UPDATE',
         'REPLACE',
         'DELETE',


### PR DESCRIPTION
Blacklist on insert keyword only instead of insert into since into is optional in at least MySQL and MS SQL