### PR TITLE
Avoid execution of parameterised queries when viewing query

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -62,7 +62,7 @@ The first setting lists the connections you want to allow Explorer to
 use. The keys of the connections dictionary are friendly names to show
 Explorer users, and the values are the actual database aliases used in
 ``settings.DATABASES``. It is highly recommended to setup read-only roles
-in your database, add them in your project's ``DATABASES`` setting and 
+in your database, add them in your project's ``DATABASES`` setting and
 use these read-only connections in the ``EXPLORER_CONNECTIONS``.
 
 If you want to quickly use django-sql-explorer with the existing default
@@ -78,7 +78,17 @@ Finally, run migrate to create the tables:
 
 ``python manage.py migrate``
 
-You can now browse to https://yoursite/explorer/ and get exploring! 
+You can now browse to https://yoursite/explorer/ and get exploring!
+
+The default behavior when viewing a parameterized query is to autorun the associated
+SQL with the default parameter values. This may perform poorly and you may want
+a chance for your users to review the parameters before running. If so you may add
+the following setting which will allow the user to view the query and adjust any
+parameters before hitting "Save & Run"
+
+.. code-block:: python
+
+    EXPLORER_AUTORUN_QUERY_WITH_PARAMS = False
 
 There are a handful of features (snapshots, emailing queries) that
 rely on Celery and the dependencies in optional-requirements.txt. If

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -131,3 +131,9 @@ FROM_EMAIL = getattr(
 UNSAFE_RENDERING = getattr(settings, "EXPLORER_UNSAFE_RENDERING", False)
 
 EXPLORER_CHARTS_ENABLED = getattr(settings, "EXPLORER_CHARTS_ENABLED", False)
+
+# If set to True will autorun queries when viewed which is the historical behavior
+# Default to True if not set in order to be backwards compatible
+# If set to False will not autorun queries containing parameters when viewed
+# - user will need to run by clicking the Save & Run Button to execute
+EXPLORER_AUTORUN_QUERY_WITH_PARAMS = getattr(settings, "EXPLORER_AUTORUN_QUERY_WITH_PARAMS", True)

--- a/explorer/views/query.py
+++ b/explorer/views/query.py
@@ -15,7 +15,7 @@ from explorer.views.auth import PermissionRequiredMixin
 from explorer.views.mixins import ExplorerContextMixin
 from explorer.views.utils import query_viewmodel
 
-from django.utils.translation import gettext_lazy as _ 
+from django.utils.translation import gettext_lazy as _
 
 class PlayQueryView(PermissionRequiredMixin, ExplorerContextMixin, View):
 
@@ -95,6 +95,9 @@ class QueryView(PermissionRequiredMixin, ExplorerContextMixin, View):
         query.save()  # updates the modified date
         show = url_get_show(request)
         rows = url_get_rows(request)
+        params = query.available_params()
+        if not app_settings.EXPLORER_AUTORUN_QUERY_WITH_PARAMS and params:
+            show = False
         vm = query_viewmodel(
             request,
             query,


### PR DESCRIPTION
Add setting which prevents autorun of parameterized queries

Issue #273