### PR TITLE
CSRF token httponly support + s3 destination for async results

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -252,6 +252,25 @@ Useful to set if you are using a non-AWS S3 service or you are using a private A
 
 
 
+S3 destination path
+********************
+
+S3 destination path. Defaults to empty string.
+Useful to set destination folder relative to S3 bucket.
+Along with settings ``EXPLORER_S3_ENDPOINT_URL`` and ``EXPLORER_S3_BUCKET`` you can specify full destination path for async query results.
+
+.. code-block:: python
+
+    EXPLORER_S3_DESTINATION = 'explorer/query'
+
+    # if
+    EXPLORER_S3_ENDPOINT_URL = 'https://amazonaws.com'
+    EXPLORER_S3_BUCKET = 'test-bucket'
+    # then files will be saved to
+    # https://amazonaws.com/test-bucket/explorer/query/filename1.csv
+    # where `filename1.csv` is generated filename
+
+
 S3 link expiration
 ******************
 

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -132,6 +132,7 @@ FROM_EMAIL = getattr(
 )
 S3_REGION = getattr(settings, "EXPLORER_S3_REGION", "us-east-1")
 S3_ENDPOINT_URL = getattr(settings, "EXPLORER_S3_ENDPOINT_URL", None)
+S3_DESTINATION = getattr(settings, "EXPLORER_S3_DESTINATION", '')
 
 UNSAFE_RENDERING = getattr(settings, "EXPLORER_UNSAFE_RENDERING", False)
 

--- a/explorer/static/explorer/js/explorer.js
+++ b/explorer/static/explorer/js/explorer.js
@@ -1,7 +1,16 @@
-var csrf_token = $.cookie(csrfCookieName);
+function getCsrfToken() {
+    if (csrfCookieHttpOnly) {
+        // get from hidden input
+        // @see https://docs.djangoproject.com/en/4.1/howto/csrf/#acquiring-csrf-token-from-html
+        return $('[name=csrfmiddlewaretoken]').val();
+    }
+
+    return $.cookie(csrfCookieName);
+}
+
 $.ajaxSetup({
     beforeSend: function(xhr) {
-        xhr.setRequestHeader("X-CSRFToken", csrf_token);
+        xhr.setRequestHeader("X-CSRFToken", getCsrfToken());
     }
 });
 

--- a/explorer/templates/explorer/base.html
+++ b/explorer/templates/explorer/base.html
@@ -20,7 +20,8 @@
     <script src="{% static 'explorer/js/jquery-ui.min.js' %}"></script>
     <script type="text/javascript">
         queryId = "{% firstof query.id 'new' %}";
-        csrfCookieName = "{% firstof csrf_cookie_name 'csrftoken' %}"
+        csrfCookieName = "{% firstof csrf_cookie_name 'csrftoken' %}";
+        csrfCookieHttpOnly = "{% firstof csrf_cookie_httponly False %}" === "True";
     </script>
     <script src="{% static 'explorer/js/explorer.js' %}"></script>
 </head>

--- a/explorer/templates/explorer/query_list.html
+++ b/explorer/templates/explorer/query_list.html
@@ -2,6 +2,7 @@
 {% load explorer_tags i18n static %}
 
 {% block sql_explorer_content %}
+    <div style="display: none">{% csrf_token %}</div>
     {% if recent_queries|length > 0 %}
         <h3>
             {% blocktrans trimmed with qlen=recent_queries|length %}

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -205,6 +205,8 @@ def get_s3_bucket():
 
 
 def s3_upload(key, data):
+    if app_settings.S3_DESTINATION:
+        key = '/'.join([app_settings.S3_DESTINATION, key])
     bucket = get_s3_bucket()
     bucket.upload_fileobj(data, key, ExtraArgs={'ContentType': "text/csv"})
     return s3_url(bucket, key)

--- a/explorer/views/mixins.py
+++ b/explorer/views/mixins.py
@@ -15,6 +15,7 @@ class ExplorerContextMixin:
                 self.request
             ),
             'csrf_cookie_name': settings.CSRF_COOKIE_NAME,
+            'csrf_cookie_httponly': settings.CSRF_COOKIE_HTTPONLY,
             'view_name': self.request.resolver_match.view_name,
         }
 


### PR DESCRIPTION
Hi!

If `CSRF_COOKIE_HTTPONLY=True`, then [email sending feature won't work](https://github.com/groveco/django-sql-explorer/issues/389#issuecomment-655511516). 
We need this setting to be True, so ask you to consider some adds:

- added support for `CSRF_COOKIE_HTTPONLY=True`: getting csrf token value from hidden input [[docs](https://docs.djangoproject.com/en/4.1/howto/csrf/#acquiring-the-token-if-csrf-use-sessions-or-csrf-cookie-httponly-is-true)]. Only on query list view, where email_csv request is made.
- added app setting `EXPLORER_S3_DESTINATION` for specify destination for async query results. Tried to use `EXPLORER_S3_S3_ENDPOINT_URL` and `EXPLORER_S3_BUCKET`, but no luck.