### PR TITLE
Test for SET PASSWORD

### DIFF
--- a/explorer/tests/test_utils.py
+++ b/explorer/tests/test_utils.py
@@ -109,7 +109,7 @@ class TestSqlBlacklist(TestCase):
         self.assertFalse(passes)
 
     def test_dml_set(self):
-        sql = "SET TIME ZONE 'PST8PDT';"
+        sql = "SET PASSWORD FOR 'user-name-here' = PASSWORD('new-password');"
         passes, words = passes_blacklist(sql)
         self.assertFalse(passes)
 


### PR DESCRIPTION
#475 added SET to the deny list because of how `SET PASSWORD` works in MySQL. #498 added a test for SET, using `SET TIME ZONE` from PostgreSQL. As far as I can tell, denying the session-specific `SET TIME ZONE` will not improve security. So test for `SET PASSWORD` instead.